### PR TITLE
Add anonymous comment section to blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,7 +5,10 @@ import { LightboxProvider } from "@/components/lightbox-provider"
 import { MdxImage } from "@/components/mdx-image"
 import { TableOfContents } from "@/components/table-of-contents"
 import { TagPill } from "@/components/tag-pill"
+import { CommentList } from "@/components/comment-list"
+import { CommentForm } from "@/components/comment-form"
 import Link from "next/link"
+import { Suspense } from "react"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 import type React from "react"
@@ -79,48 +82,74 @@ export default async function BlogPost({ params }: Props) {
   if (!post) notFound()
 
   const headings = extractHeadings(post.content)
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""
 
   return (
-    <article className="py-20 mx-auto max-w-[680px]">
-      <Link
-        href="/blog"
-        className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
-      >
-        &larr; Back to blog
-      </Link>
+    <>
+      <article className="py-20 mx-auto max-w-[680px]">
+        <Link
+          href="/blog"
+          className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
+        >
+          &larr; Back to blog
+        </Link>
 
-      <header className="mt-8">
-        <div className="flex items-center gap-3 font-mono text-xs text-text-muted">
-          <time>
-            {new Date(post.frontmatter.date).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-          <span className="text-border">·</span>
-          <span>{estimateReadTime(post.content)} min read</span>
+        <header className="mt-8">
+          <div className="flex items-center gap-3 font-mono text-xs text-text-muted">
+            <time>
+              {new Date(post.frontmatter.date).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <span className="text-border">·</span>
+            <span>{estimateReadTime(post.content)} min read</span>
+          </div>
+          <h1 className="mt-2 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+            {post.frontmatter.title}
+          </h1>
+          {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {post.frontmatter.tags.map((tag) => (
+                <TagPill key={tag}>{tag}</TagPill>
+              ))}
+            </div>
+          )}
+        </header>
+
+        <div className="relative mt-12">
+          <TableOfContents items={headings} />
+          <LightboxProvider>
+            <div className="prose-custom">
+              <MDXRemote source={post.content} components={mdxComponents} />
+            </div>
+          </LightboxProvider>
         </div>
-        <h1 className="mt-2 font-display text-3xl font-bold tracking-tight sm:text-4xl">
-          {post.frontmatter.title}
-        </h1>
-        {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (
-          <div className="mt-4 flex flex-wrap gap-2">
-            {post.frontmatter.tags.map((tag) => (
-              <TagPill key={tag}>{tag}</TagPill>
-            ))}
-          </div>
-        )}
-      </header>
+      </article>
 
-      <div className="relative mt-12">
-        <TableOfContents items={headings} />
-        <LightboxProvider>
-          <div className="prose-custom">
-            <MDXRemote source={post.content} components={mdxComponents} />
-          </div>
-        </LightboxProvider>
-      </div>
-    </article>
+      <section className="mx-auto max-w-[680px] border-t border-border pb-20">
+        <h2 className="mt-12 font-display text-xl font-semibold text-text-primary">
+          Comments
+        </h2>
+
+        <div className="mt-6">
+          <Suspense
+            fallback={
+              <p className="text-sm text-text-muted">Loading comments...</p>
+            }
+          >
+            <CommentList postSlug={slug} />
+          </Suspense>
+        </div>
+
+        <div className="mt-10">
+          <h3 className="mb-4 font-display text-base font-semibold text-text-primary">
+            Leave a comment
+          </h3>
+          <CommentForm postSlug={slug} turnstileSiteKey={turnstileSiteKey} />
+        </div>
+      </section>
+    </>
   )
 }

--- a/components/comment-form.tsx
+++ b/components/comment-form.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import Script from "next/script"
+import { addComment } from "@/lib/actions/comments"
+
+declare global {
+  interface Window {
+    turnstile?: { reset: () => void }
+  }
+}
+
+type Status = "idle" | "submitting" | "success" | "error"
+
+export function CommentForm({
+  postSlug,
+  turnstileSiteKey,
+}: {
+  postSlug: string
+  turnstileSiteKey: string
+}) {
+  const formRef = useRef<HTMLFormElement>(null)
+  const router = useRouter()
+  const [status, setStatus] = useState<Status>("idle")
+  const [errorMessage, setErrorMessage] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (status === "submitting") return
+
+    setStatus("submitting")
+    setErrorMessage("")
+
+    const formData = new FormData(formRef.current!)
+    const result = await addComment(postSlug, formData)
+
+    if (result.success) {
+      setStatus("success")
+      formRef.current?.reset()
+      window.turnstile?.reset()
+      router.refresh()
+      setTimeout(() => setStatus("idle"), 3000)
+    } else {
+      setStatus("error")
+      setErrorMessage(result.error ?? "Something went wrong.")
+    }
+  }
+
+  return (
+    <>
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+        strategy="lazyOnload"
+      />
+      <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="comment-author"
+            className="mb-1.5 block font-mono text-xs text-text-muted"
+          >
+            Name (optional)
+          </label>
+          <input
+            id="comment-author"
+            name="author"
+            type="text"
+            placeholder="Anonymous"
+            maxLength={50}
+            className="w-full rounded-lg border border-border bg-bg-surface px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="comment-body"
+            className="mb-1.5 block font-mono text-xs text-text-muted"
+          >
+            Comment
+          </label>
+          <textarea
+            id="comment-body"
+            name="body"
+            required
+            rows={4}
+            maxLength={1000}
+            placeholder="Leave a comment..."
+            className="w-full resize-none rounded-lg border border-border bg-bg-surface px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+        </div>
+
+        <div
+          className="cf-turnstile"
+          data-sitekey={turnstileSiteKey}
+          data-theme="auto"
+        />
+
+        {status === "error" && (
+          <p className="text-sm text-red-400">{errorMessage}</p>
+        )}
+
+        {status === "success" && (
+          <p className="text-sm text-accent">Comment posted.</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={status === "submitting"}
+          className="rounded border border-accent px-6 py-2.5 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+        >
+          {status === "submitting" ? "Posting..." : "Post comment"}
+        </button>
+      </form>
+    </>
+  )
+}

--- a/components/comment-list.tsx
+++ b/components/comment-list.tsx
@@ -1,0 +1,40 @@
+import { getComments } from "@/lib/db"
+
+export async function CommentList({ postSlug }: { postSlug: string }) {
+  const comments = await getComments(postSlug)
+
+  if (comments.length === 0) {
+    return (
+      <p className="text-sm text-text-muted">
+        No comments yet. Be the first to share your thoughts.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {comments.map((comment) => (
+        <div
+          key={comment.id}
+          className="rounded-lg border border-border bg-bg-surface p-4"
+        >
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs font-medium text-text-primary">
+              {comment.author}
+            </span>
+            <span className="font-mono text-xs text-text-muted">
+              {new Date(comment.created_at).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              })}
+            </span>
+          </div>
+          <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-text-secondary">
+            {comment.body}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/lib/actions/comments.ts
+++ b/lib/actions/comments.ts
@@ -1,0 +1,62 @@
+"use server"
+
+import { insertComment } from "@/lib/db"
+import { stripDangerous } from "@/lib/sanitize"
+import { revalidatePath } from "next/cache"
+
+const MAX_BODY_LENGTH = 1000
+const MAX_NAME_LENGTH = 50
+
+interface ActionResult {
+  success: boolean
+  error?: string
+}
+
+export async function addComment(
+  postSlug: string,
+  formData: FormData
+): Promise<ActionResult> {
+  const rawName = formData.get("author") as string | null
+  const rawBody = formData.get("body") as string | null
+  const token = formData.get("cf-turnstile-response") as string | null
+
+  // Validate Turnstile token
+  if (!token) {
+    return { success: false, error: "Captcha verification required." }
+  }
+
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  if (secret) {
+    const res = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ secret, response: token }),
+      }
+    )
+    const data = await res.json()
+    if (!data.success) {
+      return { success: false, error: "Captcha verification failed." }
+    }
+  }
+
+  // Validate body
+  if (!rawBody || typeof rawBody !== "string") {
+    return { success: false, error: "Comment cannot be empty." }
+  }
+
+  const body = stripDangerous(rawBody).slice(0, MAX_BODY_LENGTH)
+  if (!body) {
+    return { success: false, error: "Comment is empty after sanitization." }
+  }
+
+  const author = rawName
+    ? stripDangerous(rawName).slice(0, MAX_NAME_LENGTH) || "Anonymous"
+    : "Anonymous"
+
+  await insertComment(postSlug, author, body)
+  revalidatePath(`/blog/${postSlug}`)
+
+  return { success: true }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,6 +9,39 @@ function getDb() {
   return neon(process.env.DATABASE_URL)
 }
 
+export interface Comment {
+  id: number
+  post_slug: string
+  author: string
+  body: string
+  created_at: string
+}
+
+export async function getComments(postSlug: string): Promise<Comment[]> {
+  const sql = getDb()
+  const rows = await sql`
+    SELECT id, post_slug, author, body, created_at
+    FROM comments
+    WHERE post_slug = ${postSlug}
+    ORDER BY created_at ASC
+  `
+  return rows as Comment[]
+}
+
+export async function insertComment(
+  postSlug: string,
+  author: string,
+  body: string
+): Promise<Comment> {
+  const sql = getDb()
+  const rows = await sql`
+    INSERT INTO comments (post_slug, author, body)
+    VALUES (${postSlug}, ${author}, ${body})
+    RETURNING id, post_slug, author, body, created_at
+  `
+  return rows[0] as Comment
+}
+
 export interface StoredMessage {
   role: "user" | "assistant"
   content: string

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -18,6 +18,7 @@ export interface Comment {
 }
 
 export async function getComments(postSlug: string): Promise<Comment[]> {
+  if (!process.env.DATABASE_URL) return []
   const sql = getDb()
   const rows = await sql`
     SELECT id, post_slug, author, body, created_at

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,18 +1,20 @@
 const MAX_INPUT_CHARS = 500
 
 /**
- * Sanitize user input before sending to Anthropic API.
- *
- * Layer 6 from CLAUDE.md cost-protection spec:
- * - Strip HTML tags to prevent stored XSS if echoed back
- * - Strip common prompt-injection markers ([INST], <|system|>, etc.)
- * - Truncate to MAX_INPUT_CHARS (500) to cap input tokens
+ * Strip HTML tags and prompt-injection markers from user input.
  */
-export function sanitizeInput(input: string): string {
+export function stripDangerous(input: string): string {
   return input
     .replace(/<[^>]*>/g, "")
     .replace(/\[INST\]|\[\/INST\]/gi, "")
     .replace(/<\|system\|>|<\|user\|>|<\|assistant\|>/gi, "")
     .trim()
-    .slice(0, MAX_INPUT_CHARS)
+}
+
+/**
+ * Sanitize user input before sending to Anthropic API.
+ * Strips dangerous content and truncates to 500 chars.
+ */
+export function sanitizeInput(input: string): string {
+  return stripDangerous(input).slice(0, MAX_INPUT_CHARS)
 }


### PR DESCRIPTION
## Summary
- Anonymous comments on blog posts with optional display name
- Cloudflare Turnstile captcha for bot protection
- Comments stored in Neon PostgreSQL (table + index created)
- Server action for submission with input sanitization
- Refactored sanitize.ts to export reusable `stripDangerous` helper

## Env vars required
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (from Cloudflare Turnstile dashboard)
- `TURNSTILE_SECRET_KEY` (server-only, same dashboard)

## Test plan
- [x] Verify comment form renders below blog post content
- [x] Submit a comment with name and body, confirm it appears after refresh
- [x] Submit without name, confirm "Anonymous" is shown
- [x] Verify Turnstile widget loads and blocks submission without solving
- [x] Confirm empty/whitespace-only comments are rejected
- [x] Check comment list is empty-state when no comments exist