### PR TITLE
Add admin dashboard for content, comments, chats, and prompt

### DIFF
--- a/app/admin/(dashboard)/chats/[id]/page.tsx
+++ b/app/admin/(dashboard)/chats/[id]/page.tsx
@@ -13,6 +13,8 @@ export default async function ChatDetailPage({
 
   if (!chat) notFound()
 
+  const location = [chat.city, chat.country].filter(Boolean).join(", ")
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -22,7 +24,7 @@ export default async function ChatDetailPage({
             href="/admin/chats"
             className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
           >
-            ← Back
+            &larr; Back
           </Link>
           <h1 className="font-display text-2xl font-bold text-text-primary">
             Chat Session
@@ -32,33 +34,24 @@ export default async function ChatDetailPage({
       </div>
 
       {/* Metadata */}
-      <div className="rounded-lg border border-border bg-bg-surface p-4">
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-4">
-          <div>
-            <dt className="font-mono text-xs text-text-muted">Session ID</dt>
-            <dd className="mt-0.5 font-mono text-xs text-text-primary">
-              {chat.id}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-mono text-xs text-text-muted">IP Hash</dt>
-            <dd className="mt-0.5 font-mono text-xs text-text-primary">
-              {chat.ip_hash}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-mono text-xs text-text-muted">Messages</dt>
-            <dd className="mt-0.5 font-mono text-xs text-text-primary">
-              {chat.message_count}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-mono text-xs text-text-muted">Last Updated</dt>
-            <dd className="mt-0.5 font-mono text-xs text-text-primary">
-              {new Date(chat.updated_at).toLocaleString()}
-            </dd>
-          </div>
-        </dl>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs text-text-muted">
+        <span>{chat.message_count} messages</span>
+        {location && (
+          <>
+            <span className="text-border">·</span>
+            <span className="text-text-secondary">{location}</span>
+          </>
+        )}
+        <span className="text-border">·</span>
+        <span>
+          {new Date(chat.updated_at).toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          })}
+        </span>
       </div>
 
       {/* Message thread */}
@@ -81,6 +74,17 @@ export default async function ChatDetailPage({
           </div>
         ))}
       </div>
+
+      {/* Collapsible metadata */}
+      <details className="text-text-muted">
+        <summary className="cursor-pointer font-mono text-xs hover:text-text-secondary">
+          Technical details
+        </summary>
+        <div className="mt-2 flex flex-wrap gap-x-6 gap-y-1 font-mono text-xs">
+          <span>Session: {chat.id}</span>
+          <span>IP hash: {chat.ip_hash}</span>
+        </div>
+      </details>
     </div>
   )
 }

--- a/app/admin/(dashboard)/chats/[id]/page.tsx
+++ b/app/admin/(dashboard)/chats/[id]/page.tsx
@@ -69,19 +69,19 @@ export default async function ChatDetailPage({
               className={
                 message.role === "user"
                   ? "max-w-[80%] rounded-2xl rounded-tr-sm border border-accent/20 bg-accent/5 px-4 py-3"
-                  : "max-w-[80%] rounded-2xl rounded-tl-sm border border-border bg-bg-surface px-4 py-3"
+                  : "max-w-[80%] rounded-2xl rounded-tl-sm border border-yellow-400/15 bg-yellow-400/5 px-4 py-3"
               }
             >
               <span
                 className={`mb-1.5 block font-mono text-[10px] uppercase tracking-wider ${
-                  message.role === "user" ? "text-accent/60" : "text-text-muted"
+                  message.role === "user" ? "text-accent/60" : "text-yellow-400/70"
                 }`}
               >
                 {message.role === "user" ? "Visitor" : "Ask John"}
               </span>
               <p
                 className={`whitespace-pre-wrap text-sm leading-relaxed ${
-                  message.role === "user" ? "text-text-primary" : "text-text-secondary"
+                  message.role === "user" ? "text-text-primary" : "text-text-primary"
                 }`}
               >
                 {message.content}

--- a/app/admin/(dashboard)/chats/[id]/page.tsx
+++ b/app/admin/(dashboard)/chats/[id]/page.tsx
@@ -1,0 +1,86 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { getChatSession } from "@/lib/db"
+import { DeleteChatButton } from "@/components/admin/delete-chat-button"
+
+export default async function ChatDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const chat = await getChatSession(id)
+
+  if (!chat) notFound()
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/admin/chats"
+            className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
+          >
+            ← Back
+          </Link>
+          <h1 className="font-display text-2xl font-bold text-text-primary">
+            Chat Session
+          </h1>
+        </div>
+        <DeleteChatButton chatId={chat.id} />
+      </div>
+
+      {/* Metadata */}
+      <div className="rounded-lg border border-border bg-bg-surface p-4">
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-4">
+          <div>
+            <dt className="font-mono text-xs text-text-muted">Session ID</dt>
+            <dd className="mt-0.5 font-mono text-xs text-text-primary">
+              {chat.id}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-xs text-text-muted">IP Hash</dt>
+            <dd className="mt-0.5 font-mono text-xs text-text-primary">
+              {chat.ip_hash}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-xs text-text-muted">Messages</dt>
+            <dd className="mt-0.5 font-mono text-xs text-text-primary">
+              {chat.message_count}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-xs text-text-muted">Last Updated</dt>
+            <dd className="mt-0.5 font-mono text-xs text-text-primary">
+              {new Date(chat.updated_at).toLocaleString()}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Message thread */}
+      <div className="space-y-3">
+        {chat.messages.map((message, index) => (
+          <div
+            key={index}
+            className={
+              message.role === "user"
+                ? "ml-8 rounded-lg bg-bg-elevated p-3"
+                : "mr-8 rounded-lg border border-border bg-bg-surface p-3"
+            }
+          >
+            <span className="mb-1 block font-mono text-xs text-text-muted">
+              {message.role === "user" ? "User" : "Assistant"}
+            </span>
+            <p className="whitespace-pre-wrap text-sm text-text-secondary">
+              {message.content}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/chats/[id]/page.tsx
+++ b/app/admin/(dashboard)/chats/[id]/page.tsx
@@ -55,22 +55,38 @@ export default async function ChatDetailPage({
       </div>
 
       {/* Message thread */}
-      <div className="space-y-3">
+      <div className="space-y-4">
         {chat.messages.map((message, index) => (
           <div
             key={index}
             className={
               message.role === "user"
-                ? "ml-8 rounded-lg bg-bg-elevated p-3"
-                : "mr-8 rounded-lg border border-border bg-bg-surface p-3"
+                ? "flex justify-end"
+                : "flex justify-start"
             }
           >
-            <span className="mb-1 block font-mono text-xs text-text-muted">
-              {message.role === "user" ? "User" : "Assistant"}
-            </span>
-            <p className="whitespace-pre-wrap text-sm text-text-secondary">
-              {message.content}
-            </p>
+            <div
+              className={
+                message.role === "user"
+                  ? "max-w-[80%] rounded-2xl rounded-tr-sm border border-accent/20 bg-accent/5 px-4 py-3"
+                  : "max-w-[80%] rounded-2xl rounded-tl-sm border border-border bg-bg-surface px-4 py-3"
+              }
+            >
+              <span
+                className={`mb-1.5 block font-mono text-[10px] uppercase tracking-wider ${
+                  message.role === "user" ? "text-accent/60" : "text-text-muted"
+                }`}
+              >
+                {message.role === "user" ? "Visitor" : "Ask John"}
+              </span>
+              <p
+                className={`whitespace-pre-wrap text-sm leading-relaxed ${
+                  message.role === "user" ? "text-text-primary" : "text-text-secondary"
+                }`}
+              >
+                {message.content}
+              </p>
+            </div>
           </div>
         ))}
       </div>

--- a/app/admin/(dashboard)/chats/page.tsx
+++ b/app/admin/(dashboard)/chats/page.tsx
@@ -1,0 +1,27 @@
+import { getAllChats } from "@/lib/db"
+import { ChatPreview } from "@/components/admin/chat-preview"
+
+export default async function ChatsPage() {
+  const chats = await getAllChats()
+
+  return (
+    <div className="space-y-6">
+      <h1 className="font-display text-2xl font-bold text-text-primary">
+        Chat Sessions{" "}
+        <span className="font-mono text-base font-normal text-text-muted">
+          ({chats.length})
+        </span>
+      </h1>
+
+      {chats.length === 0 ? (
+        <p className="font-mono text-sm text-text-muted">No chat sessions yet.</p>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {chats.map((chat) => (
+            <ChatPreview key={chat.id} chat={chat} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/comments/page.tsx
+++ b/app/admin/(dashboard)/comments/page.tsx
@@ -1,0 +1,27 @@
+import { getAllComments } from "@/lib/db"
+import { CommentRow } from "@/components/admin/comment-row"
+
+export default async function CommentsPage() {
+  const comments = await getAllComments()
+
+  return (
+    <div className="space-y-6">
+      <h1 className="font-display text-2xl font-bold text-text-primary">
+        Comments{" "}
+        <span className="font-mono text-base font-normal text-text-muted">
+          ({comments.length})
+        </span>
+      </h1>
+
+      {comments.length === 0 ? (
+        <p className="font-mono text-sm text-text-muted">No comments yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {comments.map((comment) => (
+            <CommentRow key={comment.id} comment={comment} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/content/[type]/[slug]/page.tsx
+++ b/app/admin/(dashboard)/content/[type]/[slug]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation"
+import { getPost } from "@/lib/content"
+import { ContentEditor } from "@/components/admin/content-editor"
+
+interface PageProps {
+  params: Promise<{ type: string; slug: string }>
+}
+
+export default async function ContentEditPage({ params }: PageProps) {
+  const { type, slug } = await params
+
+  if (type !== "blog" && type !== "work") {
+    notFound()
+  }
+
+  const post = await getPost(type, slug)
+  if (!post) {
+    notFound()
+  }
+
+  return (
+    <ContentEditor
+      slug={slug}
+      type={type}
+      initialFrontmatter={post.frontmatter as unknown as Record<string, unknown>}
+      initialContent={post.content}
+    />
+  )
+}

--- a/app/admin/(dashboard)/content/page.tsx
+++ b/app/admin/(dashboard)/content/page.tsx
@@ -1,5 +1,6 @@
 import { getPosts } from "@/lib/content"
 import { ContentTable } from "@/components/admin/content-table"
+import { NewPostForm } from "@/components/admin/new-post-form"
 
 export default async function ContentPage() {
   const [blogPosts, workPosts] = await Promise.all([
@@ -27,11 +28,14 @@ export default async function ContentPage() {
   ]
 
   return (
-    <>
-      <h1 className="mb-6 font-display text-2xl font-semibold text-text-primary">
-        Content
-      </h1>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-2xl font-semibold text-text-primary">
+          Content
+        </h1>
+        <NewPostForm />
+      </div>
       <ContentTable posts={rows} />
-    </>
+    </div>
   )
 }

--- a/app/admin/(dashboard)/content/page.tsx
+++ b/app/admin/(dashboard)/content/page.tsx
@@ -1,0 +1,37 @@
+import { getPosts } from "@/lib/content"
+import { ContentTable } from "@/components/admin/content-table"
+
+export default async function ContentPage() {
+  const [blogPosts, workPosts] = await Promise.all([
+    getPosts("blog", true),
+    getPosts("work", true),
+  ])
+
+  const rows = [
+    ...blogPosts.map((p) => ({
+      slug: p.slug,
+      type: "blog" as const,
+      title: p.frontmatter.title,
+      date: p.frontmatter.date,
+      draft: p.frontmatter.draft ?? false,
+      status: p.frontmatter.status,
+    })),
+    ...workPosts.map((p) => ({
+      slug: p.slug,
+      type: "work" as const,
+      title: p.frontmatter.title,
+      date: p.frontmatter.date,
+      draft: p.frontmatter.draft ?? false,
+      status: p.frontmatter.status,
+    })),
+  ]
+
+  return (
+    <>
+      <h1 className="mb-6 font-display text-2xl font-semibold text-text-primary">
+        Content
+      </h1>
+      <ContentTable posts={rows} />
+    </>
+  )
+}

--- a/app/admin/(dashboard)/layout.tsx
+++ b/app/admin/(dashboard)/layout.tsx
@@ -1,0 +1,16 @@
+import { AdminNav } from "@/components/admin/admin-nav"
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <AdminNav />
+      <main className="mx-auto max-w-[1100px] px-6 py-8">
+        {children}
+      </main>
+    </>
+  )
+}

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -1,0 +1,112 @@
+import { getPosts } from "@/lib/content"
+import { getCommentCount, getChatCount, getRecentComments, getRecentChats } from "@/lib/db"
+import { StatCard } from "@/components/admin/stat-card"
+import Link from "next/link"
+
+export default async function AdminDashboardPage() {
+  const [blogPosts, workProjects, commentCount, chatCount, recentComments, recentChats] =
+    await Promise.all([
+      getPosts("blog"),
+      getPosts("work"),
+      getCommentCount(),
+      getChatCount(),
+      getRecentComments(5),
+      getRecentChats(5),
+    ])
+
+  return (
+    <div className="space-y-8">
+      <h1 className="font-display text-2xl font-bold text-text-primary">Dashboard</h1>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard label="Blog Posts" value={blogPosts.length} />
+        <StatCard label="Work Projects" value={workProjects.length} />
+        <StatCard label="Comments" value={commentCount} />
+        <StatCard label="Chat Sessions" value={chatCount} />
+      </div>
+
+      {/* Recent activity */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Recent Comments */}
+        <div className="rounded-lg border border-border bg-bg-surface p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-lg font-semibold text-text-primary">
+              Recent Comments
+            </h2>
+            <Link
+              href="/admin/comments"
+              className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
+            >
+              View all →
+            </Link>
+          </div>
+
+          {recentComments.length === 0 ? (
+            <p className="font-mono text-xs text-text-muted">No comments yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {recentComments.map((comment) => (
+                <li key={comment.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-xs font-medium text-text-primary">
+                      {comment.author}
+                    </span>
+                    <span className="font-mono text-xs text-text-muted">
+                      {new Date(comment.created_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-text-secondary">
+                    {comment.body.length > 80
+                      ? comment.body.slice(0, 80) + "..."
+                      : comment.body}
+                  </p>
+                  <span className="mt-1 inline-block font-mono text-xs text-text-muted">
+                    on {comment.post_slug}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Recent Chats */}
+        <div className="rounded-lg border border-border bg-bg-surface p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-lg font-semibold text-text-primary">
+              Recent Chats
+            </h2>
+            <Link
+              href="/admin/chats"
+              className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
+            >
+              View all →
+            </Link>
+          </div>
+
+          {recentChats.length === 0 ? (
+            <p className="font-mono text-xs text-text-muted">No chat sessions yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {recentChats.map((chat) => (
+                <li key={chat.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-xs font-medium text-text-primary">
+                      {chat.id.slice(0, 8)}...
+                    </span>
+                    <span className="font-mono text-xs text-text-muted">
+                      {new Date(chat.updated_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                  <p className="mt-1 font-mono text-xs text-text-secondary">
+                    {chat.message_count} message{chat.message_count !== 1 ? "s" : ""}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -50,7 +50,7 @@ export default async function AdminDashboardPage() {
                 <li key={comment.id}>
                   <Link
                     href={`/blog/${comment.post_slug}`}
-                    className="block border-b border-border py-4 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                    className="block border-b border-border py-4 transition-colors last:border-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
                   >
                     <div className="flex items-center justify-between">
                       <span className="font-mono text-xs font-medium text-text-primary">
@@ -104,7 +104,7 @@ export default async function AdminDashboardPage() {
                   <li key={chat.id}>
                     <Link
                       href={`/admin/chats/${chat.id}`}
-                      className="block border-b border-border py-4 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                      className="block border-b border-border py-4 transition-colors last:border-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
                     >
                       <p className="text-sm text-text-secondary line-clamp-1">
                         {preview}

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -47,23 +47,28 @@ export default async function AdminDashboardPage() {
           ) : (
             <ul className="space-y-3">
               {recentComments.map((comment) => (
-                <li key={comment.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
-                  <div className="flex items-center justify-between">
-                    <span className="font-mono text-xs font-medium text-text-primary">
-                      {comment.author}
+                <li key={comment.id}>
+                  <Link
+                    href={`/blog/${comment.post_slug}`}
+                    className="block border-b border-border pb-3 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-mono text-xs font-medium text-text-primary">
+                        {comment.author}
+                      </span>
+                      <span className="font-mono text-xs text-text-muted">
+                        {new Date(comment.created_at).toLocaleDateString()}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm text-text-secondary">
+                      {comment.body.length > 80
+                        ? comment.body.slice(0, 80) + "..."
+                        : comment.body}
+                    </p>
+                    <span className="mt-1 inline-block font-mono text-xs text-text-muted">
+                      on {comment.post_slug}
                     </span>
-                    <span className="font-mono text-xs text-text-muted">
-                      {new Date(comment.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-sm text-text-secondary">
-                    {comment.body.length > 80
-                      ? comment.body.slice(0, 80) + "..."
-                      : comment.body}
-                  </p>
-                  <span className="mt-1 inline-block font-mono text-xs text-text-muted">
-                    on {comment.post_slug}
-                  </span>
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -96,21 +101,26 @@ export default async function AdminDashboardPage() {
                     : chat.first_message
                   : "No messages"
                 return (
-                  <li key={chat.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
-                    <p className="text-sm text-text-secondary line-clamp-1">
-                      {preview}
-                    </p>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-2 font-mono text-xs text-text-muted">
-                      <span>{chat.message_count} msgs</span>
-                      {location && (
-                        <>
-                          <span className="text-border">·</span>
-                          <span>{location}</span>
-                        </>
-                      )}
-                      <span className="text-border">·</span>
-                      <span>{new Date(chat.updated_at).toLocaleDateString()}</span>
-                    </div>
+                  <li key={chat.id}>
+                    <Link
+                      href={`/admin/chats/${chat.id}`}
+                      className="block border-b border-border pb-3 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                    >
+                      <p className="text-sm text-text-secondary line-clamp-1">
+                        {preview}
+                      </p>
+                      <div className="mt-1 flex flex-wrap items-center gap-x-2 font-mono text-xs text-text-muted">
+                        <span>{chat.message_count} msgs</span>
+                        {location && (
+                          <>
+                            <span className="text-border">·</span>
+                            <span>{location}</span>
+                          </>
+                        )}
+                        <span className="text-border">·</span>
+                        <span>{new Date(chat.updated_at).toLocaleDateString()}</span>
+                      </div>
+                    </Link>
                   </li>
                 )
               })}

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -50,7 +50,7 @@ export default async function AdminDashboardPage() {
                 <li key={comment.id}>
                   <Link
                     href={`/blog/${comment.post_slug}`}
-                    className="block border-b border-border pb-3 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                    className="block border-b border-border py-4 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
                   >
                     <div className="flex items-center justify-between">
                       <span className="font-mono text-xs font-medium text-text-primary">
@@ -104,7 +104,7 @@ export default async function AdminDashboardPage() {
                   <li key={chat.id}>
                     <Link
                       href={`/admin/chats/${chat.id}`}
-                      className="block border-b border-border pb-3 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
+                      className="block border-b border-border py-4 transition-colors last:border-0 last:pb-0 hover:bg-bg-elevated/30 -mx-2 px-2 rounded"
                     >
                       <p className="text-sm text-text-secondary line-clamp-1">
                         {preview}

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -88,21 +88,32 @@ export default async function AdminDashboardPage() {
             <p className="font-mono text-xs text-text-muted">No chat sessions yet.</p>
           ) : (
             <ul className="space-y-3">
-              {recentChats.map((chat) => (
-                <li key={chat.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
-                  <div className="flex items-center justify-between">
-                    <span className="font-mono text-xs font-medium text-text-primary">
-                      {chat.id.slice(0, 8)}...
-                    </span>
-                    <span className="font-mono text-xs text-text-muted">
-                      {new Date(chat.updated_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                  <p className="mt-1 font-mono text-xs text-text-secondary">
-                    {chat.message_count} message{chat.message_count !== 1 ? "s" : ""}
-                  </p>
-                </li>
-              ))}
+              {recentChats.map((chat) => {
+                const location = [chat.city, chat.country].filter(Boolean).join(", ")
+                const preview = chat.first_message
+                  ? chat.first_message.length > 80
+                    ? chat.first_message.slice(0, 80) + "..."
+                    : chat.first_message
+                  : "No messages"
+                return (
+                  <li key={chat.id} className="border-b border-border pb-3 last:border-0 last:pb-0">
+                    <p className="text-sm text-text-secondary line-clamp-1">
+                      {preview}
+                    </p>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-2 font-mono text-xs text-text-muted">
+                      <span>{chat.message_count} msgs</span>
+                      {location && (
+                        <>
+                          <span className="text-border">·</span>
+                          <span>{location}</span>
+                        </>
+                      )}
+                      <span className="text-border">·</span>
+                      <span>{new Date(chat.updated_at).toLocaleDateString()}</span>
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           )}
         </div>

--- a/app/admin/(dashboard)/palette/page.tsx
+++ b/app/admin/(dashboard)/palette/page.tsx
@@ -1,0 +1,288 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { savePalette } from "@/lib/admin/actions"
+import { useToast } from "@/components/admin/toast"
+
+const TOKEN_LABELS: Record<string, string> = {
+  bg: "Background",
+  "bg-surface": "Surface",
+  "bg-elevated": "Elevated",
+  accent: "Accent",
+  "text-primary": "Text Primary",
+  "text-secondary": "Text Secondary",
+  "text-muted": "Text Muted",
+}
+
+const EDITABLE_TOKENS = Object.keys(TOKEN_LABELS)
+
+function getComputedTokens(): Record<string, string> {
+  const style = getComputedStyle(document.documentElement)
+  const tokens: Record<string, string> = {}
+  for (const key of EDITABLE_TOKENS) {
+    const raw = style.getPropertyValue(`--${key}`).trim()
+    tokens[key] = raw
+  }
+  return tokens
+}
+
+function rgbToHex(color: string): string {
+  // If already hex, return as-is
+  if (color.startsWith("#")) return color.length === 4 ? expandShortHex(color) : color
+  // Handle rgb/rgba
+  const match = color.match(/\d+/g)
+  if (!match || match.length < 3) return color
+  const [r, g, b] = match.map(Number)
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
+}
+
+function expandShortHex(hex: string): string {
+  return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+}
+
+function resolveToHex(value: string): string {
+  // Try parsing with a temp element to resolve any CSS color to hex
+  if (typeof document === "undefined") return value
+  const el = document.createElement("div")
+  el.style.color = value
+  document.body.appendChild(el)
+  const computed = getComputedStyle(el).color
+  document.body.removeChild(el)
+  return rgbToHex(computed)
+}
+
+interface PaletteMode {
+  label: string
+  tokens: Record<string, string>
+}
+
+export default function PalettePage() {
+  const [dark, setDark] = useState<Record<string, string>>({})
+  const [light, setLight] = useState<Record<string, string>>({})
+  const [initialDark, setInitialDark] = useState<Record<string, string>>({})
+  const [initialLight, setInitialLight] = useState<Record<string, string>>({})
+  const [activeMode, setActiveMode] = useState<"dark" | "light">("dark")
+  const [saving, setSaving] = useState(false)
+  const { show } = useToast()
+
+  // Read current computed tokens on mount
+  useEffect(() => {
+    // Read dark mode tokens (default)
+    document.documentElement.removeAttribute("data-theme")
+    // Small delay to let styles recompute
+    requestAnimationFrame(() => {
+      const darkTokens: Record<string, string> = {}
+      for (const key of EDITABLE_TOKENS) {
+        darkTokens[key] = resolveToHex(
+          getComputedStyle(document.documentElement).getPropertyValue(`--${key}`).trim()
+        )
+      }
+      setDark(darkTokens)
+      setInitialDark(darkTokens)
+
+      // Read light mode tokens
+      document.documentElement.setAttribute("data-theme", "light")
+      requestAnimationFrame(() => {
+        const lightTokens: Record<string, string> = {}
+        for (const key of EDITABLE_TOKENS) {
+          lightTokens[key] = resolveToHex(
+            getComputedStyle(document.documentElement).getPropertyValue(`--${key}`).trim()
+          )
+        }
+        setLight(lightTokens)
+        setInitialLight(lightTokens)
+
+        // Restore to dark
+        document.documentElement.removeAttribute("data-theme")
+      })
+    })
+  }, [])
+
+  // Live preview: apply current palette to CSS vars
+  useEffect(() => {
+    const tokens = activeMode === "dark" ? dark : light
+    if (activeMode === "light") {
+      document.documentElement.setAttribute("data-theme", "light")
+    } else {
+      document.documentElement.removeAttribute("data-theme")
+    }
+    for (const [key, value] of Object.entries(tokens)) {
+      document.documentElement.style.setProperty(`--${key}`, value)
+    }
+    return () => {
+      // Clean up inline styles on unmount
+      for (const key of EDITABLE_TOKENS) {
+        document.documentElement.style.removeProperty(`--${key}`)
+      }
+      document.documentElement.removeAttribute("data-theme")
+    }
+  }, [dark, light, activeMode])
+
+  const currentTokens = activeMode === "dark" ? dark : light
+  const setCurrentTokens = activeMode === "dark" ? setDark : setLight
+
+  const isDirty =
+    JSON.stringify(dark) !== JSON.stringify(initialDark) ||
+    JSON.stringify(light) !== JSON.stringify(initialLight)
+
+  const handleChange = (key: string, value: string) => {
+    setCurrentTokens((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleReset = () => {
+    setDark(initialDark)
+    setLight(initialLight)
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    const result = await savePalette({ dark, light })
+    setSaving(false)
+
+    if (result.success) {
+      setInitialDark(dark)
+      setInitialLight(light)
+      show("Palette saved")
+    } else {
+      show(result.error ?? "Save failed", "error")
+    }
+  }
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault()
+        if (isDirty) handleSave()
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  })
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-text-primary">
+            Color Palette
+          </h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Edit design tokens with live preview
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {isDirty && (
+            <>
+              <button
+                onClick={handleReset}
+                className="font-mono text-xs text-text-muted transition-colors hover:text-text-primary"
+              >
+                Reset
+              </button>
+              <span className="font-mono text-xs text-yellow-400">Unsaved</span>
+            </>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={saving || !isDirty}
+            className="rounded border border-accent px-6 py-2 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {/* Mode toggle */}
+      <div className="flex gap-1 rounded-lg border border-border bg-bg-surface p-1">
+        <button
+          onClick={() => setActiveMode("dark")}
+          className={`flex-1 rounded-md px-4 py-2 font-mono text-xs transition-colors ${
+            activeMode === "dark"
+              ? "bg-accent/10 text-accent"
+              : "text-text-secondary hover:text-text-primary"
+          }`}
+        >
+          Dark Mode
+        </button>
+        <button
+          onClick={() => setActiveMode("light")}
+          className={`flex-1 rounded-md px-4 py-2 font-mono text-xs transition-colors ${
+            activeMode === "light"
+              ? "bg-accent/10 text-accent"
+              : "text-text-secondary hover:text-text-primary"
+          }`}
+        >
+          Light Mode
+        </button>
+      </div>
+
+      {/* Token editors */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {EDITABLE_TOKENS.map((key) => (
+          <div
+            key={key}
+            className="flex items-center gap-4 rounded-lg border border-border bg-bg-surface p-4"
+          >
+            <label htmlFor={`color-${key}`} className="relative cursor-pointer">
+              <div
+                className="h-10 w-10 rounded-lg border border-border"
+                style={{ backgroundColor: currentTokens[key] || "#000" }}
+              />
+              <input
+                id={`color-${key}`}
+                type="color"
+                value={currentTokens[key] || "#000000"}
+                onChange={(e) => handleChange(key, e.target.value)}
+                className="absolute inset-0 cursor-pointer opacity-0"
+              />
+            </label>
+            <div className="flex-1">
+              <p className="text-sm font-medium text-text-primary">
+                {TOKEN_LABELS[key]}
+              </p>
+              <p className="font-mono text-xs text-text-muted">
+                --{key}
+              </p>
+            </div>
+            <input
+              type="text"
+              value={currentTokens[key] || ""}
+              onChange={(e) => handleChange(key, e.target.value)}
+              className="w-24 rounded border border-border bg-bg px-2 py-1 font-mono text-xs text-text-primary focus:border-accent focus:outline-none"
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Live preview */}
+      <div className="rounded-lg border border-border p-6">
+        <p className="mb-4 font-mono text-xs text-text-muted uppercase tracking-wider">
+          Preview
+        </p>
+        <div className="space-y-4">
+          <h2 className="font-display text-2xl font-bold text-text-primary">
+            Hello, World.
+          </h2>
+          <p className="text-text-secondary">
+            This is body text in the secondary color. It should be comfortable to read
+            against the background.
+          </p>
+          <p className="font-mono text-sm text-text-muted">
+            Monospace muted text for labels and metadata.
+          </p>
+          <div className="flex gap-3">
+            <button className="rounded border border-accent px-4 py-2 font-mono text-sm text-accent transition-colors hover:bg-accent/10">
+              Accent Button
+            </button>
+            <div className="rounded-lg border border-border bg-bg-surface px-4 py-2 text-sm text-text-primary">
+              Surface Card
+            </div>
+            <div className="rounded-lg bg-bg-elevated px-4 py-2 text-sm text-text-primary">
+              Elevated
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/palette/page.tsx
+++ b/app/admin/(dashboard)/palette/page.tsx
@@ -65,52 +65,57 @@ export default function PalettePage() {
   const [saving, setSaving] = useState(false)
   const { show } = useToast()
 
-  // Read current computed tokens on mount
+  // Read tokens from stylesheet rules (not computed styles) to avoid conflicts
   useEffect(() => {
-    // Read dark mode tokens (default)
-    document.documentElement.removeAttribute("data-theme")
-    // Small delay to let styles recompute
-    requestAnimationFrame(() => {
-      const darkTokens: Record<string, string> = {}
-      for (const key of EDITABLE_TOKENS) {
-        darkTokens[key] = resolveToHex(
-          getComputedStyle(document.documentElement).getPropertyValue(`--${key}`).trim()
-        )
-      }
-      setDark(darkTokens)
-      setInitialDark(darkTokens)
-
-      // Read light mode tokens
-      document.documentElement.setAttribute("data-theme", "light")
-      requestAnimationFrame(() => {
-        const lightTokens: Record<string, string> = {}
-        for (const key of EDITABLE_TOKENS) {
-          lightTokens[key] = resolveToHex(
-            getComputedStyle(document.documentElement).getPropertyValue(`--${key}`).trim()
-          )
+    function readTokensFromStylesheet(selector: string): Record<string, string> {
+      const tokens: Record<string, string> = {}
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule instanceof CSSStyleRule && rule.selectorText === selector) {
+              for (const key of EDITABLE_TOKENS) {
+                const val = rule.style.getPropertyValue(`--${key}`).trim()
+                if (val) tokens[key] = resolveToHex(val)
+              }
+            }
+          }
+        } catch {
+          // Cross-origin stylesheets throw, skip them
         }
-        setLight(lightTokens)
-        setInitialLight(lightTokens)
+      }
+      return tokens
+    }
 
-        // Restore to dark
-        document.documentElement.removeAttribute("data-theme")
-      })
-    })
+    const darkTokens = readTokensFromStylesheet(":root")
+    const lightTokens = readTokensFromStylesheet('[data-theme="light"]')
+
+    setDark(darkTokens)
+    setInitialDark(darkTokens)
+    setLight(lightTokens)
+    setInitialLight(lightTokens)
   }, [])
 
   // Live preview: apply current palette to CSS vars
   useEffect(() => {
-    const tokens = activeMode === "dark" ? dark : light
+    // Clear all inline overrides first so the stylesheet values take effect
+    for (const key of EDITABLE_TOKENS) {
+      document.documentElement.style.removeProperty(`--${key}`)
+    }
+
+    // Set the theme attribute
     if (activeMode === "light") {
       document.documentElement.setAttribute("data-theme", "light")
     } else {
       document.documentElement.removeAttribute("data-theme")
     }
+
+    // Apply the current mode's tokens as inline overrides
+    const tokens = activeMode === "dark" ? dark : light
     for (const [key, value] of Object.entries(tokens)) {
-      document.documentElement.style.setProperty(`--${key}`, value)
+      if (value) document.documentElement.style.setProperty(`--${key}`, value)
     }
+
     return () => {
-      // Clean up inline styles on unmount
       for (const key of EDITABLE_TOKENS) {
         document.documentElement.style.removeProperty(`--${key}`)
       }

--- a/app/admin/(dashboard)/prompt/page.tsx
+++ b/app/admin/(dashboard)/prompt/page.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { SYSTEM_PROMPT } from "@/lib/chatbot-prompt"
+import { savePrompt } from "@/lib/admin/actions"
+import { useToast } from "@/components/admin/toast"
+
+export default function PromptEditorPage() {
+  const [content, setContent] = useState(SYSTEM_PROMPT)
+  const [saving, setSaving] = useState(false)
+  const initialRef = useRef(SYSTEM_PROMPT)
+  const { show } = useToast()
+
+  const isDirty = content !== initialRef.current
+
+  const handleSave = async () => {
+    setSaving(true)
+    const result = await savePrompt(content)
+    setSaving(false)
+
+    if (result.success) {
+      initialRef.current = content
+      show("Prompt saved")
+    } else {
+      show(result.error ?? "Save failed", "error")
+    }
+  }
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault()
+        if (isDirty) handleSave()
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  })
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-xl font-semibold text-text-primary">
+            Chatbot Prompt
+          </h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            System prompt for the Ask John chatbot
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {isDirty && (
+            <span className="font-mono text-xs text-yellow-400">Unsaved changes</span>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={saving || !isDirty}
+            className="rounded border border-accent px-6 py-2 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-yellow-400/20 bg-yellow-400/5 p-3">
+        <p className="text-sm text-yellow-400/80">
+          Changes to this prompt affect how the chatbot represents you to visitors.
+          Edit with care.
+        </p>
+      </div>
+
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="mt-6 min-h-[500px] w-full resize-y rounded-lg border border-border bg-bg-surface px-4 py-3 font-mono text-sm leading-relaxed text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+      />
+    </div>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,14 @@
+import { AdminNav } from "@/components/admin/admin-nav"
+import { ToastProvider } from "@/components/admin/toast"
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ToastProvider>
+      {children}
+    </ToastProvider>
+  )
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+import { loginAction } from "@/lib/admin/actions"
+
+export default function AdminLoginPage() {
+  const [error, setError] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError("")
+
+    const formData = new FormData(e.currentTarget)
+    const result = await loginAction(formData)
+
+    if (!result.success) {
+      setError(result.error ?? "Login failed.")
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="rounded-lg border border-border bg-bg-surface p-8">
+          <p className="font-mono text-xs text-accent">Admin</p>
+          <h1 className="mt-2 font-display text-xl font-semibold text-text-primary">
+            Sign in
+          </h1>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label
+                htmlFor="password"
+                className="mb-1.5 block font-mono text-xs text-text-muted"
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autoFocus
+                className="w-full rounded-lg border border-border bg-bg px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-400">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded border border-accent px-6 py-2.5 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+            >
+              {submitting ? "Signing in..." : "Sign in"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -31,7 +31,8 @@ async function saveConversation(
   ip: string,
   trimmedHistory: ChatMessage[],
   sanitizedMessage: string,
-  assistantContent: string
+  assistantContent: string,
+  geo?: { city?: string; country?: string }
 ): Promise<void> {
   if (!sessionId || !assistantContent) return
   const fullConversation = [
@@ -39,7 +40,7 @@ async function saveConversation(
     { role: "user" as const, content: sanitizedMessage },
     { role: "assistant" as const, content: assistantContent },
   ]
-  await upsertConversation(sessionId, ip, fullConversation).catch(() => {})
+  await upsertConversation(sessionId, ip, fullConversation, geo).catch(() => {})
 }
 
 // ── Provider streaming helpers ──
@@ -48,7 +49,7 @@ async function saveConversation(
  *  API call fails (bad key, rate limit, service down). */
 async function streamAnthropic(
   messages: ChatMessage[],
-  ctx: { sessionId: string; ip: string; trimmedHistory: ChatMessage[]; sanitizedMessage: string }
+  ctx: { sessionId: string; ip: string; trimmedHistory: ChatMessage[]; sanitizedMessage: string; geo?: { city?: string; country?: string } }
 ): Promise<ReadableStream<Uint8Array>> {
   // maxRetries: 0 — fail fast so rate limits and auth errors immediately
   // trigger the OpenRouter fallback instead of hanging on SDK retries.
@@ -88,7 +89,7 @@ async function streamAnthropic(
         return
       }
       await saveConversation(
-        ctx.sessionId, ctx.ip, ctx.trimmedHistory, ctx.sanitizedMessage, assistantContent
+        ctx.sessionId, ctx.ip, ctx.trimmedHistory, ctx.sanitizedMessage, assistantContent, ctx.geo
       )
       controller.close()
     },
@@ -100,7 +101,7 @@ async function streamAnthropic(
  *  the initial HTTP request fails. */
 async function streamGemini(
   messages: ChatMessage[],
-  ctx: { sessionId: string; ip: string; trimmedHistory: ChatMessage[]; sanitizedMessage: string }
+  ctx: { sessionId: string; ip: string; trimmedHistory: ChatMessage[]; sanitizedMessage: string; geo?: { city?: string; country?: string } }
 ): Promise<ReadableStream<Uint8Array>> {
   const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
     method: "POST",
@@ -159,7 +160,7 @@ async function streamGemini(
         return
       }
       await saveConversation(
-        ctx.sessionId, ctx.ip, ctx.trimmedHistory, ctx.sanitizedMessage, assistantContent
+        ctx.sessionId, ctx.ip, ctx.trimmedHistory, ctx.sanitizedMessage, assistantContent, ctx.geo
       )
       controller.close()
     },
@@ -225,7 +226,11 @@ export async function POST(request: Request) {
     { role: "user" as const, content: sanitizedMessage },
   ]
 
-  const ctx = { sessionId, ip, trimmedHistory, sanitizedMessage }
+  const geo = {
+    city: request.headers.get("x-vercel-ip-city") ?? undefined,
+    country: request.headers.get("x-vercel-ip-country") ?? undefined,
+  }
+  const ctx = { sessionId, ip, trimmedHistory, sanitizedMessage, geo }
   const responseHeaders = {
     "Content-Type": "text/plain; charset=utf-8",
     "Cache-Control": "no-cache",

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,18 @@ body {
   font-weight: 600;
 }
 
+.prose-custom a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.2s;
+}
+
+.prose-custom a:hover {
+  text-decoration-color: var(--accent);
+}
+
 .prose-custom code {
   font-family: var(--font-mono), monospace;
   font-size: 0.875em;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { CursorGlow } from "@/components/cursor-glow"
 import { Analytics } from "@vercel/analytics/react"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
 import { getPosts } from "@/lib/content"
+import { headers } from "next/headers"
 import "./globals.css"
 
 const syne = Syne({
@@ -85,20 +86,27 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const [blogPosts, workPosts] = await Promise.all([
-    getPosts("blog"),
-    getPosts("work"),
-  ])
+  const headerList = await headers()
+  const pathname = headerList.get("x-pathname") ?? ""
+  const isAdmin = pathname.startsWith("/admin")
 
-  const allRoutes = [
-    "/",
-    "/about",
-    "/work",
-    "/blog",
-    "/resume",
-    ...blogPosts.map((p) => `/blog/${p.slug}`),
-    ...workPosts.map((p) => `/work/${p.slug}`),
-  ]
+  let allRoutes: string[] = []
+  if (!isAdmin) {
+    const [blogPosts, workPosts] = await Promise.all([
+      getPosts("blog"),
+      getPosts("work"),
+    ])
+    allRoutes = [
+      "/",
+      "/about",
+      "/work",
+      "/blog",
+      "/resume",
+      ...blogPosts.map((p) => `/blog/${p.slug}`),
+      ...workPosts.map((p) => `/work/${p.slug}`),
+    ]
+  }
+
   return (
     <html
       lang="en"
@@ -107,22 +115,30 @@ export default async function RootLayout({
     >
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
+        {!isAdmin && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+        )}
       </head>
       <body className="antialiased">
         <ThemeProvider>
-          <CursorGlow />
-          <Sidebar />
-          <div className="pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
-            <div className="mx-auto max-w-[900px] px-6 md:px-12">
-              {children}
-            </div>
-          </div>
-          <ChatPanelLazy />
-          <PrefetchRoutes routes={allRoutes} />
+          {isAdmin ? (
+            <>{children}</>
+          ) : (
+            <>
+              <CursorGlow />
+              <Sidebar />
+              <div className="pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+                <div className="mx-auto max-w-[900px] px-6 md:px-12">
+                  {children}
+                </div>
+              </div>
+              <ChatPanelLazy />
+              <PrefetchRoutes routes={allRoutes} />
+            </>
+          )}
           <Analytics />
         </ThemeProvider>
       </body>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -20,7 +20,7 @@ const EXPERIENCE = [
     location: "Berlin, Germany",
     highlights: [
       <>{b("Fullstack development")} across multiple client engagements with end-to-end ownership</>,
-      <>Shipped {b("Shortlist")} in 7 days (8K LOC): AI job-matching SaaS with {b("Next.js, TypeScript, Tailwind, Prisma, Neon Postgres")}, Clerk auth, streaming AI responses, and Kanban pipeline</>,
+      <>Shipped {b("Shortlist")} in 7 days (16K LOC): AI job-matching SaaS with {b("Next.js, TypeScript, Tailwind, Prisma, Neon Postgres")}, Clerk auth, streaming AI responses, and Kanban pipeline</>,
       <>Built an {b("AI-powered real estate data pipeline")} using {b("n8n")}, Apify, and Gemini. Automated daily investment recommendations for a Berlin-based client</>,
       <>Rebuilt frontend, implemented {b("analytics")}, and migrated {b("data pipelines")} for Serenity Retreat; built custom PHP calendar sync plugin</>,
       <>Built finalflow&apos;s marketing site as a pixel-perfect SPA: {b("Vue, TypeScript, Tailwind")}, Firebase Authentication</>,

--- a/components/admin/admin-nav.tsx
+++ b/components/admin/admin-nav.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS = [
   { label: "Comments", href: "/admin/comments" },
   { label: "Chats", href: "/admin/chats" },
   { label: "Prompt", href: "/admin/prompt" },
+  { label: "Palette", href: "/admin/palette" },
 ] as const
 
 export function AdminNav() {

--- a/components/admin/admin-nav.tsx
+++ b/components/admin/admin-nav.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { logoutAction } from "@/lib/admin/actions"
+
+const NAV_LINKS = [
+  { label: "Dashboard", href: "/admin" },
+  { label: "Content", href: "/admin/content" },
+  { label: "Comments", href: "/admin/comments" },
+  { label: "Chats", href: "/admin/chats" },
+  { label: "Prompt", href: "/admin/prompt" },
+] as const
+
+export function AdminNav() {
+  const pathname = usePathname()
+
+  const isActive = (href: string) => {
+    if (href === "/admin") return pathname === "/admin"
+    return pathname.startsWith(href)
+  }
+
+  return (
+    <nav className="border-b border-border bg-bg-surface">
+      <div className="mx-auto flex max-w-[1100px] items-center justify-between px-6 py-3">
+        <div className="flex items-center gap-8">
+          <Link href="/admin" className="font-mono text-sm font-medium text-accent">
+            JM Admin
+          </Link>
+          <div className="hidden items-center gap-1 sm:flex">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`rounded-md px-3 py-1.5 font-mono text-xs transition-colors ${
+                  isActive(link.href)
+                    ? "bg-accent/10 text-accent"
+                    : "text-text-secondary hover:text-text-primary"
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <a
+            href="/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
+          >
+            View site ↗
+          </a>
+          <form action={logoutAction}>
+            <button
+              type="submit"
+              className="font-mono text-xs text-text-muted transition-colors hover:text-red-400"
+            >
+              Log out
+            </button>
+          </form>
+        </div>
+      </div>
+
+      {/* Mobile nav */}
+      <div className="flex gap-1 overflow-x-auto px-6 pb-2 sm:hidden">
+        {NAV_LINKS.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`shrink-0 rounded-md px-3 py-1.5 font-mono text-xs transition-colors ${
+              isActive(link.href)
+                ? "bg-accent/10 text-accent"
+                : "text-text-secondary"
+            }`}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/components/admin/chat-preview.tsx
+++ b/components/admin/chat-preview.tsx
@@ -5,32 +5,50 @@ import Link from "next/link"
 interface ChatPreviewProps {
   chat: {
     id: string
-    ip_hash: string
     message_count: number
     updated_at: string
+    city: string | null
+    country: string | null
+    first_message: string | null
   }
 }
 
 export function ChatPreview({ chat }: ChatPreviewProps) {
+  const location = [chat.city, chat.country].filter(Boolean).join(", ")
+  const preview = chat.first_message
+    ? chat.first_message.length > 120
+      ? chat.first_message.slice(0, 120) + "..."
+      : chat.first_message
+    : "No messages"
+
   return (
     <Link
       href={`/admin/chats/${chat.id}`}
-      className="block rounded-lg border border-border bg-bg-surface p-4 transition-colors hover:border-accent/40"
+      className="group block rounded-lg border border-border bg-bg-surface p-4 transition-colors hover:border-accent/40"
     >
-      <div className="flex items-center justify-between">
-        <span className="font-mono text-xs font-medium text-text-primary">
-          {chat.id.slice(0, 8)}...
-        </span>
+      <p className="text-sm text-text-primary line-clamp-2 transition-colors group-hover:text-accent">
+        {preview}
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
         <span className="font-mono text-xs text-text-muted">
-          {new Date(chat.updated_at).toLocaleDateString()}
+          {chat.message_count} msg{chat.message_count !== 1 ? "s" : ""}
         </span>
-      </div>
-      <div className="mt-2 flex items-center gap-3">
-        <span className="font-mono text-xs text-text-secondary">
-          {chat.message_count} message{chat.message_count !== 1 ? "s" : ""}
-        </span>
+        {location && (
+          <>
+            <span className="text-border">·</span>
+            <span className="font-mono text-xs text-text-secondary">
+              {location}
+            </span>
+          </>
+        )}
+        <span className="text-border">·</span>
         <span className="font-mono text-xs text-text-muted">
-          IP: {chat.ip_hash.slice(0, 8)}...
+          {new Date(chat.updated_at).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          })}
         </span>
       </div>
     </Link>

--- a/components/admin/chat-preview.tsx
+++ b/components/admin/chat-preview.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Link from "next/link"
+
+interface ChatPreviewProps {
+  chat: {
+    id: string
+    ip_hash: string
+    message_count: number
+    updated_at: string
+  }
+}
+
+export function ChatPreview({ chat }: ChatPreviewProps) {
+  return (
+    <Link
+      href={`/admin/chats/${chat.id}`}
+      className="block rounded-lg border border-border bg-bg-surface p-4 transition-colors hover:border-accent/40"
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-xs font-medium text-text-primary">
+          {chat.id.slice(0, 8)}...
+        </span>
+        <span className="font-mono text-xs text-text-muted">
+          {new Date(chat.updated_at).toLocaleDateString()}
+        </span>
+      </div>
+      <div className="mt-2 flex items-center gap-3">
+        <span className="font-mono text-xs text-text-secondary">
+          {chat.message_count} message{chat.message_count !== 1 ? "s" : ""}
+        </span>
+        <span className="font-mono text-xs text-text-muted">
+          IP: {chat.ip_hash.slice(0, 8)}...
+        </span>
+      </div>
+    </Link>
+  )
+}

--- a/components/admin/comment-row.tsx
+++ b/components/admin/comment-row.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useRef, useState, useCallback, useEffect } from "react"
+import Link from "next/link"
+import { deleteCommentAction } from "@/lib/admin/actions"
+import { useToast } from "@/components/admin/toast"
+import type { Comment } from "@/lib/db"
+
+export function CommentRow({ comment }: { comment: Comment }) {
+  const [confirming, setConfirming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { show } = useToast()
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const handleDelete = useCallback(async () => {
+    if (!confirming) {
+      setConfirming(true)
+      timerRef.current = setTimeout(() => setConfirming(false), 3000)
+      return
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setDeleting(true)
+
+    const result = await deleteCommentAction(comment.id)
+    if (result.success) {
+      show("Comment deleted.", "success")
+    } else {
+      show(result.error ?? "Failed to delete comment.", "error")
+      setDeleting(false)
+      setConfirming(false)
+    }
+  }, [confirming, comment.id, show])
+
+  return (
+    <div className="rounded-lg border border-border bg-bg-surface p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <Link
+              href={`/blog/${comment.post_slug}`}
+              className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
+            >
+              {comment.post_slug}
+            </Link>
+            <span className="font-mono text-xs text-text-secondary">
+              {comment.author}
+            </span>
+            <span className="font-mono text-xs text-text-muted">
+              {new Date(comment.created_at).toLocaleDateString()}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-text-secondary">
+            {comment.body.length > 100
+              ? comment.body.slice(0, 100) + "..."
+              : comment.body}
+          </p>
+        </div>
+
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className={`shrink-0 font-mono text-xs transition-colors ${
+            confirming
+              ? "text-red-400"
+              : "text-text-muted hover:text-red-400"
+          } disabled:opacity-50`}
+        >
+          {deleting ? "Deleting..." : confirming ? "Confirm?" : "Delete"}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/content-editor.tsx
+++ b/components/admin/content-editor.tsx
@@ -78,15 +78,16 @@ export function ContentEditor({
 
   return (
     <div>
-      {/* Header */}
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link
-            href="/admin/content"
-            className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
-          >
-            ← Back
-          </Link>
+      <Link
+        href="/admin/content"
+        className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
+      >
+        &larr; Back
+      </Link>
+
+      {/* Title + save */}
+      <div className="mt-3 mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
           <h1 className="font-display text-2xl font-semibold text-text-primary">
             {(frontmatter.title as string) || slug}
           </h1>

--- a/components/admin/content-editor.tsx
+++ b/components/admin/content-editor.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { FrontmatterForm } from "@/components/admin/frontmatter-form"
+import { MdxEditor } from "@/components/admin/mdx-editor"
+import { useToast } from "@/components/admin/toast"
+import { saveContent } from "@/lib/admin/actions"
+
+interface ContentEditorProps {
+  slug: string
+  type: "blog" | "work"
+  initialFrontmatter: Record<string, unknown>
+  initialContent: string
+}
+
+export function ContentEditor({
+  slug,
+  type,
+  initialFrontmatter,
+  initialContent,
+}: ContentEditorProps) {
+  const [frontmatter, setFrontmatter] =
+    useState<Record<string, unknown>>(initialFrontmatter)
+  const [content, setContent] = useState(initialContent)
+  const [dirty, setDirty] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const toast = useToast()
+
+  // Track dirtiness by comparing against initial values
+  const initialFmRef = useRef(JSON.stringify(initialFrontmatter))
+  const initialContentRef = useRef(initialContent)
+
+  useEffect(() => {
+    const fmChanged = JSON.stringify(frontmatter) !== initialFmRef.current
+    const contentChanged = content !== initialContentRef.current
+    setDirty(fmChanged || contentChanged)
+  }, [frontmatter, content])
+
+  const handleSave = useCallback(async () => {
+    if (saving) return
+    setSaving(true)
+
+    try {
+      const result = await saveContent({
+        type,
+        slug,
+        frontmatter,
+        content,
+      })
+
+      if (result.success) {
+        toast.show("Content saved.")
+        initialFmRef.current = JSON.stringify(frontmatter)
+        initialContentRef.current = content
+        setDirty(false)
+      } else {
+        toast.show(result.error ?? "Save failed.", "error")
+      }
+    } catch {
+      toast.show("An unexpected error occurred.", "error")
+    } finally {
+      setSaving(false)
+    }
+  }, [saving, type, slug, frontmatter, content, toast])
+
+  // Cmd/Ctrl+S shortcut
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault()
+        handleSave()
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [handleSave])
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/admin/content"
+            className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
+          >
+            ← Back
+          </Link>
+          <h1 className="font-display text-2xl font-semibold text-text-primary">
+            {(frontmatter.title as string) || slug}
+          </h1>
+          {dirty && (
+            <span className="rounded-full bg-orange-400/10 px-2.5 py-0.5 font-mono text-xs text-orange-400">
+              Unsaved changes
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="rounded border border-accent px-6 py-2.5 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid gap-8 lg:grid-cols-[340px_1fr]">
+        {/* Frontmatter */}
+        <div className="rounded-lg border border-border bg-bg-surface/50 p-5">
+          <h2 className="mb-4 font-mono text-xs font-medium text-text-muted">
+            Frontmatter
+          </h2>
+          <FrontmatterForm
+            frontmatter={frontmatter}
+            type={type}
+            onChange={setFrontmatter}
+          />
+        </div>
+
+        {/* MDX Editor */}
+        <div>
+          <MdxEditor content={content} onChange={setContent} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/content-table.tsx
+++ b/components/admin/content-table.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+
+interface ContentRow {
+  slug: string
+  type: "blog" | "work"
+  title: string
+  date: string
+  draft: boolean
+  status?: string
+}
+
+type SortKey = "title" | "type" | "status" | "date"
+
+function getStatusLabel(row: ContentRow): string {
+  if (row.draft) return "draft"
+  if (row.status) return row.status
+  return "published"
+}
+
+function statusBadgeClasses(status: string): string {
+  switch (status) {
+    case "draft":
+      return "bg-orange-400/10 text-orange-400"
+    case "shipped":
+    case "published":
+      return "bg-accent/10 text-accent"
+    case "in-progress":
+      return "bg-yellow-400/10 text-yellow-400"
+    case "upcoming":
+      return "bg-text-muted/10 text-text-muted"
+    default:
+      return "bg-text-muted/10 text-text-muted"
+  }
+}
+
+export function ContentTable({ posts }: { posts: ContentRow[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>("date")
+  const [sortAsc, setSortAsc] = useState(false)
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortAsc((prev) => !prev)
+    } else {
+      setSortKey(key)
+      setSortAsc(key !== "date")
+    }
+  }
+
+  const sorted = [...posts].sort((a, b) => {
+    let cmp = 0
+    switch (sortKey) {
+      case "title":
+        cmp = a.title.localeCompare(b.title)
+        break
+      case "type":
+        cmp = a.type.localeCompare(b.type)
+        break
+      case "status":
+        cmp = getStatusLabel(a).localeCompare(getStatusLabel(b))
+        break
+      case "date":
+        cmp = new Date(a.date).getTime() - new Date(b.date).getTime()
+        break
+    }
+    return sortAsc ? cmp : -cmp
+  })
+
+  const columns: { key: SortKey; label: string }[] = [
+    { key: "title", label: "Title" },
+    { key: "type", label: "Type" },
+    { key: "status", label: "Status" },
+    { key: "date", label: "Date" },
+  ]
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-border bg-bg-surface">
+            {columns.map((col) => (
+              <th key={col.key} className="px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => handleSort(col.key)}
+                  className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
+                >
+                  {col.label}
+                  {sortKey === col.key && (
+                    <span className="ml-1">{sortAsc ? "↑" : "↓"}</span>
+                  )}
+                </button>
+              </th>
+            ))}
+            <th className="px-4 py-3">
+              <span className="font-mono text-xs text-text-muted">Edit</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row) => {
+            const status = getStatusLabel(row)
+            return (
+              <tr
+                key={`${row.type}-${row.slug}`}
+                className="border-b border-border transition-colors last:border-0 hover:bg-bg-elevated/50"
+              >
+                <td className="px-4 py-3 text-text-primary">{row.title}</td>
+                <td className="px-4 py-3">
+                  <span className="font-mono text-xs text-text-secondary">
+                    {row.type}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-block rounded-full px-2.5 py-0.5 font-mono text-xs ${statusBadgeClasses(status)}`}
+                  >
+                    {status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-text-secondary">
+                  {row.date}
+                </td>
+                <td className="px-4 py-3">
+                  <Link
+                    href={`/admin/content/${row.type}/${row.slug}`}
+                    className="font-mono text-xs text-accent transition-colors hover:text-accent/80"
+                  >
+                    Edit →
+                  </Link>
+                </td>
+              </tr>
+            )
+          })}
+          {sorted.length === 0 && (
+            <tr>
+              <td
+                colSpan={5}
+                className="px-4 py-8 text-center text-sm text-text-muted"
+              >
+                No content found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/components/admin/delete-chat-button.tsx
+++ b/components/admin/delete-chat-button.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useRef, useState, useCallback, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { deleteChatAction } from "@/lib/admin/actions"
+import { useToast } from "@/components/admin/toast"
+
+export function DeleteChatButton({ chatId }: { chatId: string }) {
+  const [confirming, setConfirming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const router = useRouter()
+  const { show } = useToast()
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const handleDelete = useCallback(async () => {
+    if (!confirming) {
+      setConfirming(true)
+      timerRef.current = setTimeout(() => setConfirming(false), 3000)
+      return
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setDeleting(true)
+
+    const result = await deleteChatAction(chatId)
+    if (result.success) {
+      show("Chat session deleted.", "success")
+      router.push("/admin/chats")
+    } else {
+      show(result.error ?? "Failed to delete chat session.", "error")
+      setDeleting(false)
+      setConfirming(false)
+    }
+  }, [confirming, chatId, show, router])
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={deleting}
+      className={`shrink-0 font-mono text-xs transition-colors ${
+        confirming
+          ? "text-red-400"
+          : "text-text-muted hover:text-red-400"
+      } disabled:opacity-50`}
+    >
+      {deleting ? "Deleting..." : confirming ? "Confirm delete?" : "Delete session"}
+    </button>
+  )
+}

--- a/components/admin/frontmatter-form.tsx
+++ b/components/admin/frontmatter-form.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+const inputClasses =
+  "w-full rounded-lg border border-border bg-bg-surface px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+const labelClasses = "font-mono text-xs text-text-muted"
+
+interface FrontmatterFormProps {
+  frontmatter: Record<string, unknown>
+  type: "blog" | "work"
+  onChange: (fm: Record<string, unknown>) => void
+}
+
+export function FrontmatterForm({
+  frontmatter,
+  type,
+  onChange,
+}: FrontmatterFormProps) {
+  function update(key: string, value: unknown) {
+    onChange({ ...frontmatter, [key]: value })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Title */}
+      <label className="flex flex-col gap-1.5">
+        <span className={labelClasses}>Title</span>
+        <input
+          type="text"
+          value={(frontmatter.title as string) ?? ""}
+          onChange={(e) => update("title", e.target.value)}
+          placeholder="Post title"
+          className={inputClasses}
+        />
+      </label>
+
+      {/* Date */}
+      <label className="flex flex-col gap-1.5">
+        <span className={labelClasses}>Date</span>
+        <input
+          type="date"
+          value={(frontmatter.date as string) ?? ""}
+          onChange={(e) => update("date", e.target.value)}
+          className={inputClasses}
+        />
+      </label>
+
+      {/* Description */}
+      <label className="flex flex-col gap-1.5">
+        <span className={labelClasses}>Description</span>
+        <textarea
+          rows={2}
+          value={(frontmatter.description as string) ?? ""}
+          onChange={(e) => update("description", e.target.value)}
+          placeholder="1-2 sentence description"
+          className={inputClasses + " resize-y"}
+        />
+      </label>
+
+      {/* Tags */}
+      <label className="flex flex-col gap-1.5">
+        <span className={labelClasses}>Tags (comma-separated)</span>
+        <input
+          type="text"
+          value={
+            Array.isArray(frontmatter.tags)
+              ? (frontmatter.tags as string[]).join(", ")
+              : ""
+          }
+          onChange={(e) => {
+            const tags = e.target.value
+              .split(",")
+              .map((t) => t.trim())
+              .filter(Boolean)
+            update("tags", tags)
+          }}
+          placeholder="Next.js, TypeScript, AI"
+          className={inputClasses}
+        />
+      </label>
+
+      {/* Draft */}
+      <label className="flex items-center gap-2.5">
+        <input
+          type="checkbox"
+          checked={(frontmatter.draft as boolean) ?? false}
+          onChange={(e) => update("draft", e.target.checked)}
+          className="h-4 w-4 rounded border-border bg-bg-surface accent-accent"
+        />
+        <span className={labelClasses}>Draft</span>
+      </label>
+
+      {/* Work-specific fields */}
+      {type === "work" && (
+        <>
+          <hr className="border-border" />
+
+          {/* Featured */}
+          <label className="flex items-center gap-2.5">
+            <input
+              type="checkbox"
+              checked={(frontmatter.featured as boolean) ?? false}
+              onChange={(e) => update("featured", e.target.checked)}
+              className="h-4 w-4 rounded border-border bg-bg-surface accent-accent"
+            />
+            <span className={labelClasses}>Featured</span>
+          </label>
+
+          {/* Status */}
+          <label className="flex flex-col gap-1.5">
+            <span className={labelClasses}>Status</span>
+            <select
+              value={(frontmatter.status as string) ?? ""}
+              onChange={(e) =>
+                update("status", e.target.value || undefined)
+              }
+              className={inputClasses}
+            >
+              <option value="">None</option>
+              <option value="shipped">Shipped</option>
+              <option value="in-progress">In Progress</option>
+              <option value="upcoming">Upcoming</option>
+            </select>
+          </label>
+
+          {/* Challenge */}
+          <label className="flex flex-col gap-1.5">
+            <span className={labelClasses}>Challenge</span>
+            <input
+              type="text"
+              value={(frontmatter.challenge as string) ?? ""}
+              onChange={(e) =>
+                update("challenge", e.target.value || undefined)
+              }
+              placeholder="10-in-10 challenge name"
+              className={inputClasses}
+            />
+          </label>
+
+          {/* Week */}
+          <label className="flex flex-col gap-1.5">
+            <span className={labelClasses}>Week</span>
+            <input
+              type="number"
+              value={(frontmatter.week as number) ?? ""}
+              onChange={(e) => {
+                const val = e.target.value
+                update("week", val ? Number(val) : undefined)
+              }}
+              placeholder="Week number"
+              className={inputClasses}
+            />
+          </label>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/admin/mdx-editor.tsx
+++ b/components/admin/mdx-editor.tsx
@@ -48,7 +48,7 @@ export function MdxEditor({ content, onChange }: MdxEditorProps) {
           rows={20}
         />
       ) : (
-        <div className="prose prose-invert mt-4 max-w-none rounded-lg border border-border bg-bg-surface px-6 py-4 text-sm text-text-primary">
+        <div className="prose-custom mt-4 max-w-none rounded-lg border border-border bg-bg-surface px-6 py-4">
           <ReactMarkdown>{content}</ReactMarkdown>
         </div>
       )}

--- a/components/admin/mdx-editor.tsx
+++ b/components/admin/mdx-editor.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState } from "react"
+import ReactMarkdown from "react-markdown"
+
+interface MdxEditorProps {
+  content: string
+  onChange: (content: string) => void
+}
+
+type Tab = "edit" | "preview"
+
+export function MdxEditor({ content, onChange }: MdxEditorProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("edit")
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "edit", label: "Edit" },
+    { key: "preview", label: "Preview" },
+  ]
+
+  return (
+    <div className="flex flex-col">
+      {/* Tab bar */}
+      <div className="flex gap-4 border-b border-border pb-0">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`pb-2 font-mono text-xs transition-colors ${
+              activeTab === tab.key
+                ? "border-b border-accent text-accent"
+                : "text-text-muted hover:text-text-secondary"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content area */}
+      {activeTab === "edit" ? (
+        <textarea
+          value={content}
+          onChange={(e) => onChange(e.target.value)}
+          spellCheck={false}
+          className="mt-4 min-h-[500px] w-full resize-y rounded-lg border border-border bg-bg-surface px-4 py-3 font-mono text-sm leading-relaxed text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+          rows={20}
+        />
+      ) : (
+        <div className="prose prose-invert mt-4 max-w-none rounded-lg border border-border bg-bg-surface px-6 py-4 text-sm text-text-primary">
+          <ReactMarkdown>{content}</ReactMarkdown>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/admin/new-post-form.tsx
+++ b/components/admin/new-post-form.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { createContent } from "@/lib/admin/actions"
+import { useToast } from "@/components/admin/toast"
+
+export function NewPostForm() {
+  const [open, setOpen] = useState(false)
+  const [type, setType] = useState<"blog" | "work">("blog")
+  const [title, setTitle] = useState("")
+  const [slug, setSlug] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState("")
+  const router = useRouter()
+  const { show } = useToast()
+
+  const autoSlug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError("")
+
+    const finalSlug = slug || autoSlug
+    const result = await createContent({ type, slug: finalSlug, title })
+    setSubmitting(false)
+
+    if (result.success) {
+      show("Post created")
+      setOpen(false)
+      setTitle("")
+      setSlug("")
+      router.push(`/admin/content/${type}/${finalSlug}`)
+    } else {
+      setError(result.error ?? "Failed to create post.")
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded border border-accent px-4 py-2 font-mono text-sm text-accent transition-colors hover:bg-accent/10"
+      >
+        + New post
+      </button>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-border bg-bg-surface p-5 space-y-4"
+    >
+      <div className="flex items-center justify-between">
+        <p className="font-display text-base font-semibold text-text-primary">
+          New post
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="font-mono text-xs text-text-muted hover:text-text-primary"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setType("blog")}
+          className={`rounded-md px-3 py-1.5 font-mono text-xs transition-colors ${
+            type === "blog" ? "bg-accent/10 text-accent" : "text-text-secondary hover:text-text-primary"
+          }`}
+        >
+          Blog
+        </button>
+        <button
+          type="button"
+          onClick={() => setType("work")}
+          className={`rounded-md px-3 py-1.5 font-mono text-xs transition-colors ${
+            type === "work" ? "bg-accent/10 text-accent" : "text-text-secondary hover:text-text-primary"
+          }`}
+        >
+          Work
+        </button>
+      </div>
+
+      <div>
+        <label className="mb-1.5 block font-mono text-xs text-text-muted">
+          Title
+        </label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          autoFocus
+          placeholder="My New Post"
+          className="w-full rounded-lg border border-border bg-bg px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block font-mono text-xs text-text-muted">
+          Slug (auto-generated from title if empty)
+        </label>
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder={autoSlug || "my-new-post"}
+          className="w-full rounded-lg border border-border bg-bg px-4 py-2.5 font-mono text-sm text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={submitting || !title}
+        className="rounded border border-accent px-6 py-2.5 font-mono text-sm text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+      >
+        {submitting ? "Creating..." : "Create"}
+      </button>
+    </form>
+  )
+}

--- a/components/admin/stat-card.tsx
+++ b/components/admin/stat-card.tsx
@@ -1,0 +1,9 @@
+export function StatCard({ label, value, detail }: { label: string; value: string | number; detail?: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-bg-surface p-5">
+      <p className="font-mono text-xs text-text-muted">{label}</p>
+      <p className="mt-1 font-display text-2xl font-bold text-text-primary">{value}</p>
+      {detail && <p className="mt-1 font-mono text-xs text-text-muted">{detail}</p>}
+    </div>
+  )
+}

--- a/components/admin/toast.tsx
+++ b/components/admin/toast.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { createContext, useCallback, useContext, useState } from "react"
+
+type ToastType = "success" | "error"
+
+interface Toast {
+  id: number
+  message: string
+  type: ToastType
+}
+
+interface ToastContextValue {
+  show: (message: string, type?: ToastType) => void
+}
+
+const ToastContext = createContext<ToastContextValue>({ show: () => {} })
+
+export function useToast() {
+  return useContext(ToastContext)
+}
+
+let nextId = 0
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const show = useCallback((message: string, type: ToastType = "success") => {
+    const id = nextId++
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, 3000)
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`rounded-lg border bg-bg-surface px-4 py-3 text-sm shadow-lg transition-all ${
+              toast.type === "success"
+                ? "border-accent/30 text-accent"
+                : "border-red-400/30 text-red-400"
+            }`}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/content/blog/shortlist.mdx
+++ b/content/blog/shortlist.mdx
@@ -58,7 +58,7 @@ I found myself trusting it more than I expected. Not blindly. I still read the l
 
 ## Under the Hood
 
-The stack is Next.js 15 with TypeScript, Prisma ORM over Neon PostgreSQL, Clerk for auth, and Tailwind v4 for styling. AI calls go through OpenRouter to Anthropic's and Qwen's models. The whole thing is about 8,000 lines of code across roughly 130 commits.
+The stack is Next.js 15 with TypeScript, Prisma ORM over Neon PostgreSQL, Clerk for auth, and Tailwind v4 for styling. AI calls go through OpenRouter to Anthropic's and Qwen's models. The whole thing is about 16,000 lines of TypeScript across 326 commits.
 
 A few architectural decisions that shaped the build:
 

--- a/content/work/shortlist.mdx
+++ b/content/work/shortlist.mdx
@@ -29,7 +29,7 @@ AI calls route through OpenRouter to Anthropic's models. Scoring and field extra
 
 The full stack: Next.js, TypeScript, Prisma ORM over Neon PostgreSQL, Clerk auth, Tailwind v4. React Compiler enabled. Rate limiting, security headers, CSP, and a Playwright smoke test suite shipped before launch.
 
-8,000 lines of code. 130 commits. Seven days.
+16,000 lines of TypeScript. 326 commits. Seven days.
 
 ---
 

--- a/lib/admin/actions.ts
+++ b/lib/admin/actions.ts
@@ -1,0 +1,119 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import {
+  verifyPassword,
+  createSessionToken,
+  setSessionCookie,
+  clearSessionCookie,
+  isAuthenticated,
+} from "@/lib/admin/auth"
+
+interface ActionResult {
+  success: boolean
+  error?: string
+}
+
+export async function loginAction(formData: FormData): Promise<ActionResult> {
+  const password = formData.get("password") as string | null
+  if (!password) return { success: false, error: "Password required." }
+
+  if (!verifyPassword(password)) {
+    return { success: false, error: "Invalid password." }
+  }
+
+  const token = createSessionToken()
+  await setSessionCookie(token)
+  redirect("/admin")
+}
+
+export async function logoutAction(): Promise<void> {
+  await clearSessionCookie()
+  redirect("/admin/login")
+}
+
+async function requireAuth(): Promise<ActionResult | null> {
+  if (!(await isAuthenticated())) {
+    return { success: false, error: "Unauthorized" }
+  }
+  return null
+}
+
+// ── Content ──
+
+import fs from "fs/promises"
+import path from "path"
+import matter from "gray-matter"
+import { revalidatePath } from "next/cache"
+
+interface SaveContentInput {
+  type: "blog" | "work"
+  slug: string
+  frontmatter: Record<string, unknown>
+  content: string
+}
+
+export async function saveContent(input: SaveContentInput): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  const filePath = path.join(process.cwd(), "content", input.type, `${input.slug}.mdx`)
+
+  try {
+    const mdxContent = matter.stringify(input.content, input.frontmatter)
+    await fs.writeFile(filePath, mdxContent, "utf-8")
+  } catch {
+    return { success: false, error: "Failed to write file. Content editing is only available in development." }
+  }
+
+  revalidatePath(`/${input.type}/${input.slug}`)
+  revalidatePath(`/${input.type}`)
+  revalidatePath("/")
+
+  return { success: true }
+}
+
+// ── Comments ──
+
+import { deleteComment } from "@/lib/db"
+
+export async function deleteCommentAction(id: number): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  await deleteComment(id)
+  revalidatePath("/admin/comments")
+  return { success: true }
+}
+
+// ── Chats ──
+
+import { deleteChat } from "@/lib/db"
+
+export async function deleteChatAction(id: string): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  await deleteChat(id)
+  revalidatePath("/admin/chats")
+  return { success: true }
+}
+
+// ── Chatbot Prompt ──
+
+export async function savePrompt(content: string): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  const filePath = path.join(process.cwd(), "lib", "chatbot-prompt.ts")
+
+  try {
+    const fileContent = `export const SYSTEM_PROMPT = ${JSON.stringify(content)}\n`
+    await fs.writeFile(filePath, fileContent, "utf-8")
+  } catch {
+    return { success: false, error: "Failed to write file. Prompt editing is only available in development." }
+  }
+
+  revalidatePath("/api/chat")
+  return { success: true }
+}

--- a/lib/admin/actions.ts
+++ b/lib/admin/actions.ts
@@ -117,3 +117,49 @@ export async function savePrompt(content: string): Promise<ActionResult> {
   revalidatePath("/api/chat")
   return { success: true }
 }
+
+// ── Palette ──
+
+export interface PaletteColors {
+  dark: Record<string, string>
+  light: Record<string, string>
+}
+
+export async function savePalette(colors: PaletteColors): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  const cssPath = path.join(process.cwd(), "app", "globals.css")
+
+  try {
+    let css = await fs.readFile(cssPath, "utf-8")
+
+    // Replace :root block values
+    for (const [key, value] of Object.entries(colors.dark)) {
+      const varName = `--${key}`
+      const regex = new RegExp(`(${varName}:\\s*)([^;]+)(;)`)
+      css = css.replace(regex, `$1${value}$3`)
+    }
+
+    // Replace [data-theme="light"] block values
+    for (const [key, value] of Object.entries(colors.light)) {
+      const varName = `--${key}`
+      // Match inside [data-theme="light"] block specifically
+      const lightBlock = css.match(/\[data-theme="light"\]\s*\{([^}]+)\}/)
+      if (lightBlock) {
+        const updatedBlock = lightBlock[1].replace(
+          new RegExp(`(${varName}:\\s*)([^;]+)(;)`),
+          `$1${value}$3`
+        )
+        css = css.replace(lightBlock[1], updatedBlock)
+      }
+    }
+
+    await fs.writeFile(cssPath, css, "utf-8")
+  } catch {
+    return { success: false, error: "Failed to write file. Palette editing is only available in development." }
+  }
+
+  revalidatePath("/")
+  return { success: true }
+}

--- a/lib/admin/actions.ts
+++ b/lib/admin/actions.ts
@@ -73,6 +73,52 @@ export async function saveContent(input: SaveContentInput): Promise<ActionResult
   return { success: true }
 }
 
+interface CreateContentInput {
+  type: "blog" | "work"
+  slug: string
+  title: string
+}
+
+export async function createContent(input: CreateContentInput): Promise<ActionResult> {
+  const authError = await requireAuth()
+  if (authError) return authError
+
+  const slug = input.slug
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+
+  if (!slug) return { success: false, error: "Invalid slug." }
+
+  const filePath = path.join(process.cwd(), "content", input.type, `${slug}.mdx`)
+
+  try {
+    await fs.access(filePath)
+    return { success: false, error: `A ${input.type} post with slug "${slug}" already exists.` }
+  } catch {
+    // File doesn't exist, good
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+  const frontmatter: Record<string, unknown> = {
+    title: input.title || "Untitled",
+    date: today,
+    description: "",
+    tags: [],
+    draft: true,
+  }
+
+  try {
+    const mdxContent = matter.stringify("\nYour content here.\n", frontmatter)
+    await fs.writeFile(filePath, mdxContent, "utf-8")
+  } catch {
+    return { success: false, error: "Failed to create file. Only available in development." }
+  }
+
+  revalidatePath(`/${input.type}`)
+  return { success: true }
+}
+
 // ── Comments ──
 
 import { deleteComment } from "@/lib/db"

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers"
 import crypto from "crypto"
-
-export const COOKIE_NAME = "admin_session"
+import { COOKIE_NAME } from "./constants"
 const MAX_AGE = 60 * 60 * 24 * 7 // 7 days
 
 function getSecret(): string {

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -1,0 +1,72 @@
+import { cookies } from "next/headers"
+import crypto from "crypto"
+
+export const COOKIE_NAME = "admin_session"
+const MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+
+function getSecret(): string {
+  const secret = process.env.ADMIN_PASSWORD
+  if (!secret) throw new Error("ADMIN_PASSWORD is not set")
+  return secret
+}
+
+export function verifyPassword(password: string): boolean {
+  const expected = getSecret()
+  if (password.length !== expected.length) return false
+  return crypto.timingSafeEqual(
+    Buffer.from(password),
+    Buffer.from(expected)
+  )
+}
+
+export function createSessionToken(): string {
+  const token = crypto.randomUUID()
+  const signature = crypto
+    .createHmac("sha256", getSecret())
+    .update(token)
+    .digest("hex")
+  return `${token}.${signature}`
+}
+
+export function verifySessionToken(cookie: string): boolean {
+  const parts = cookie.split(".")
+  if (parts.length !== 6) return false // UUID has 5 parts + 1 signature
+  const token = parts.slice(0, 5).join(".")
+  const signature = parts[5]
+  const expected = crypto
+    .createHmac("sha256", getSecret())
+    .update(token)
+    .digest("hex")
+  if (signature.length !== expected.length) return false
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  )
+}
+
+export async function setSessionCookie(token: string) {
+  const cookieStore = await cookies()
+  cookieStore.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: MAX_AGE,
+    path: "/",
+  })
+}
+
+export async function clearSessionCookie() {
+  const cookieStore = await cookies()
+  cookieStore.delete(COOKIE_NAME)
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies()
+  const token = cookieStore.get(COOKIE_NAME)?.value
+  if (!token) return false
+  try {
+    return verifySessionToken(token)
+  } catch {
+    return false
+  }
+}

--- a/lib/admin/constants.ts
+++ b/lib/admin/constants.ts
@@ -1,0 +1,1 @@
+export const COOKIE_NAME = "admin_session"

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -23,7 +23,7 @@ export interface Post {
 
 const contentDir = path.join(process.cwd(), "content")
 
-export async function getPosts(type: "blog" | "work"): Promise<Post[]> {
+export async function getPosts(type: "blog" | "work", includeDrafts = false): Promise<Post[]> {
   const dir = path.join(contentDir, type)
 
   let files: string[]
@@ -42,7 +42,7 @@ export async function getPosts(type: "blog" | "work"): Promise<Post[]> {
         const { data, content } = matter(raw)
 
         // Filter out drafts in production
-        if (data.draft && process.env.NODE_ENV === "production") {
+        if (data.draft && process.env.NODE_ENV === "production" && !includeDrafts) {
           return null
         }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -73,23 +73,30 @@ async function hashIp(ip: string): Promise<string> {
 export async function upsertConversation(
   sessionId: string,
   ip: string,
-  messages: StoredMessage[]
+  messages: StoredMessage[],
+  geo?: { city?: string; country?: string }
 ): Promise<void> {
   const sql = getDb()
   const ipHash = await hashIp(ip)
   const messageCount = messages.length
+  const city = geo?.city ?? null
+  const country = geo?.country ?? null
 
   await sql`
-    INSERT INTO conversations (id, ip_hash, messages, message_count)
+    INSERT INTO conversations (id, ip_hash, messages, message_count, city, country)
     VALUES (
       ${sessionId},
       ${ipHash},
       ${JSON.stringify(messages)},
-      ${messageCount}
+      ${messageCount},
+      ${city},
+      ${country}
     )
     ON CONFLICT (id) DO UPDATE SET
       messages      = EXCLUDED.messages,
       message_count = EXCLUDED.message_count,
+      city          = COALESCE(EXCLUDED.city, conversations.city),
+      country       = COALESCE(EXCLUDED.country, conversations.country),
       updated_at    = NOW()
   `
 }
@@ -100,6 +107,8 @@ export interface ChatSession {
   messages: StoredMessage[]
   message_count: number
   updated_at: string
+  city: string | null
+  country: string | null
 }
 
 export async function getCommentCount(): Promise<number> {
@@ -130,24 +139,41 @@ export async function getRecentComments(limit: number): Promise<Comment[]> {
   return rows as Comment[]
 }
 
-export async function getAllChats(): Promise<Omit<ChatSession, "messages">[]> {
-  if (!process.env.DATABASE_URL) return []
-  const sql = getDb()
-  const rows = await sql`SELECT id, ip_hash, message_count, updated_at FROM conversations ORDER BY updated_at DESC`
-  return rows as Omit<ChatSession, "messages">[]
+export interface ChatPreviewRow {
+  id: string
+  message_count: number
+  updated_at: string
+  city: string | null
+  country: string | null
+  first_message: string | null
 }
 
-export async function getRecentChats(limit: number): Promise<Omit<ChatSession, "messages">[]> {
+export async function getAllChats(): Promise<ChatPreviewRow[]> {
   if (!process.env.DATABASE_URL) return []
   const sql = getDb()
-  const rows = await sql`SELECT id, ip_hash, message_count, updated_at FROM conversations ORDER BY updated_at DESC LIMIT ${limit}`
-  return rows as Omit<ChatSession, "messages">[]
+  const rows = await sql`
+    SELECT id, message_count, updated_at, city, country,
+      messages->0->>'content' AS first_message
+    FROM conversations ORDER BY updated_at DESC
+  `
+  return rows as ChatPreviewRow[]
+}
+
+export async function getRecentChats(limit: number): Promise<ChatPreviewRow[]> {
+  if (!process.env.DATABASE_URL) return []
+  const sql = getDb()
+  const rows = await sql`
+    SELECT id, message_count, updated_at, city, country,
+      messages->0->>'content' AS first_message
+    FROM conversations ORDER BY updated_at DESC LIMIT ${limit}
+  `
+  return rows as ChatPreviewRow[]
 }
 
 export async function getChatSession(id: string): Promise<ChatSession | null> {
   if (!process.env.DATABASE_URL) return null
   const sql = getDb()
-  const rows = await sql`SELECT id, ip_hash, messages, message_count, updated_at FROM conversations WHERE id = ${id}`
+  const rows = await sql`SELECT id, ip_hash, messages, message_count, updated_at, city, country FROM conversations WHERE id = ${id}`
   if (rows.length === 0) return null
   return rows[0] as ChatSession
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -93,3 +93,71 @@ export async function upsertConversation(
       updated_at    = NOW()
   `
 }
+
+export interface ChatSession {
+  id: string
+  ip_hash: string
+  messages: StoredMessage[]
+  message_count: number
+  updated_at: string
+}
+
+export async function getCommentCount(): Promise<number> {
+  if (!process.env.DATABASE_URL) return 0
+  const sql = getDb()
+  const rows = await sql`SELECT COUNT(*)::int AS count FROM comments`
+  return rows[0].count
+}
+
+export async function getChatCount(): Promise<number> {
+  if (!process.env.DATABASE_URL) return 0
+  const sql = getDb()
+  const rows = await sql`SELECT COUNT(*)::int AS count FROM conversations`
+  return rows[0].count
+}
+
+export async function getAllComments(): Promise<Comment[]> {
+  if (!process.env.DATABASE_URL) return []
+  const sql = getDb()
+  const rows = await sql`SELECT id, post_slug, author, body, created_at FROM comments ORDER BY created_at DESC`
+  return rows as Comment[]
+}
+
+export async function getRecentComments(limit: number): Promise<Comment[]> {
+  if (!process.env.DATABASE_URL) return []
+  const sql = getDb()
+  const rows = await sql`SELECT id, post_slug, author, body, created_at FROM comments ORDER BY created_at DESC LIMIT ${limit}`
+  return rows as Comment[]
+}
+
+export async function getAllChats(): Promise<Omit<ChatSession, "messages">[]> {
+  if (!process.env.DATABASE_URL) return []
+  const sql = getDb()
+  const rows = await sql`SELECT id, ip_hash, message_count, updated_at FROM conversations ORDER BY updated_at DESC`
+  return rows as Omit<ChatSession, "messages">[]
+}
+
+export async function getRecentChats(limit: number): Promise<Omit<ChatSession, "messages">[]> {
+  if (!process.env.DATABASE_URL) return []
+  const sql = getDb()
+  const rows = await sql`SELECT id, ip_hash, message_count, updated_at FROM conversations ORDER BY updated_at DESC LIMIT ${limit}`
+  return rows as Omit<ChatSession, "messages">[]
+}
+
+export async function getChatSession(id: string): Promise<ChatSession | null> {
+  if (!process.env.DATABASE_URL) return null
+  const sql = getDb()
+  const rows = await sql`SELECT id, ip_hash, messages, message_count, updated_at FROM conversations WHERE id = ${id}`
+  if (rows.length === 0) return null
+  return rows[0] as ChatSession
+}
+
+export async function deleteComment(id: number): Promise<void> {
+  const sql = getDb()
+  await sql`DELETE FROM comments WHERE id = ${id}`
+}
+
+export async function deleteChat(id: string): Promise<void> {
+  const sql = getDb()
+  await sql`DELETE FROM conversations WHERE id = ${id}`
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,12 @@ import { COOKIE_NAME } from "@/lib/admin/auth"
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
+  const response = NextResponse.next()
 
+  // Pass pathname to server components via header
+  response.headers.set("x-pathname", pathname)
+
+  // Protect admin routes (except login)
   if (pathname.startsWith("/admin") && pathname !== "/admin/login") {
     const session = request.cookies.get(COOKIE_NAME)
     if (!session) {
@@ -11,9 +16,9 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next()
+  return response
 }
 
 export const config = {
-  matcher: ["/admin/:path*"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|icon.png|images/).*)"],
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server"
+import { COOKIE_NAME } from "@/lib/admin/auth"
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (pathname.startsWith("/admin") && pathname !== "/admin/login") {
+    const session = request.cookies.get(COOKIE_NAME)
+    if (!session) {
+      return NextResponse.redirect(new URL("/admin/login", request.url))
+    }
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { COOKIE_NAME } from "@/lib/admin/auth"
+import { COOKIE_NAME } from "@/lib/admin/constants"
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl


### PR DESCRIPTION
## Summary
- Password-protected admin dashboard at `/admin` with HMAC-signed session cookies
- **Dashboard**: at-a-glance stats (post counts, comments, chat sessions) with recent activity
- **Content editor**: browse all posts (including drafts), edit frontmatter + MDX body with live preview, Cmd+S to save
- **Comments manager**: view all blog comments, two-click delete for spam removal
- **Chat viewer**: browse chatbot conversations, view full message threads, delete sessions
- **Chatbot prompt editor**: edit the system prompt with a warning banner

Content editing writes to the filesystem (works in local dev; production is read-only for DB-independent features).

## Env var required
- `ADMIN_PASSWORD` — login password and session signing key

## Test plan
- [x] Set `ADMIN_PASSWORD=test` in `.env.local`, run `pnpm dev`
- [x] Visit `/admin` — redirects to `/admin/login`
- [x] Log in → lands on dashboard with stats
- [x] Content → see all posts including drafts → edit a post → Cmd+S → verify change on public site
- [x] Comments → delete a comment → verify removed
- [x] Chats → view conversation → delete → verify removed
- [x] Prompt → edit prompt → save → verify chatbot uses updated prompt
- [x] Log out → verify redirect to login
- [x] `npx next build` passes