### PR TITLE
Add animated PCB circuit board background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,14 +20,14 @@
 }
 
 [data-theme="light"] {
-  --bg:             #f0f4f8;   /* cool blue-grey, the daylight version of the navy */
-  --bg-surface:     #e3ecf3;   /* cards, panels */
-  --bg-elevated:    #d6e3ee;   /* hover states */
-  --accent:         #0891b2;   /* cyan-600, same family as mint, readable on light */
-  --text-primary:   #0d1b2e;   /* deep navy, mirrors dark mode bg tones */
-  --text-secondary: #374e6a;   /* blue-grey */
-  --text-muted:     #6b87a4;   /* muted blue-grey */
-  --border:         rgba(0, 0, 0, 0.08);
+  --bg:             #e4eaf0;   /* cool blue-grey, slightly deeper */
+  --bg-surface:     #d8e2ec;   /* cards, panels */
+  --bg-elevated:    #cad7e3;   /* hover states */
+  --accent:         #0780a0;   /* cyan-700, darker for better contrast */
+  --text-primary:   #081422;   /* deeper navy */
+  --text-secondary: #2e4260;   /* darker blue-grey */
+  --text-muted:     #5c7691;   /* darker muted blue-grey */
+  --border:         rgba(0, 0, 0, 0.10);
   --cursor-glow:    transparent;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { ChatPanelLazy } from "@/components/chat-panel-lazy"
 import { CursorGlow } from "@/components/cursor-glow"
 import { Analytics } from "@vercel/analytics/react"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
-import { CircuitBg } from "@/components/circuit-bg"
+import { CircuitBgLazy } from "@/components/circuit-bg-lazy"
 import { getPosts } from "@/lib/content"
 import { headers } from "next/headers"
 import "./globals.css"
@@ -132,7 +132,7 @@ export default async function RootLayout({
               <CursorGlow />
               <Sidebar />
               <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
-                <CircuitBg />
+                <CircuitBgLazy />
                 <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
                   {children}
                 </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -133,7 +133,7 @@ export default async function RootLayout({
               <Sidebar />
               <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
                 <CircuitBg />
-                <div className="mx-auto max-w-[900px] px-6 md:px-12">
+                <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
                   {children}
                 </div>
               </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ChatPanelLazy } from "@/components/chat-panel-lazy"
 import { CursorGlow } from "@/components/cursor-glow"
 import { Analytics } from "@vercel/analytics/react"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
+import { CircuitBg } from "@/components/circuit-bg"
 import { getPosts } from "@/lib/content"
 import { headers } from "next/headers"
 import "./globals.css"
@@ -130,7 +131,8 @@ export default async function RootLayout({
             <>
               <CursorGlow />
               <Sidebar />
-              <div className="pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+              <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+                <CircuitBg />
                 <div className="mx-auto max-w-[900px] px-6 md:px-12">
                   {children}
                 </div>

--- a/components/circuit-bg-lazy.tsx
+++ b/components/circuit-bg-lazy.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const CircuitBg = dynamic(
+  () => import("./circuit-bg").then((mod) => mod.CircuitBg),
+  { ssr: false }
+)
+
+export function CircuitBgLazy() {
+  return <CircuitBg />
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -87,14 +87,13 @@ export function CircuitBg() {
         paths.push({ x, y, dir, history: [{ x, y }], maxLen, alive: true, width, isBundle, blockedCount: 0 })
       }
 
-      // Seed parallel bundles from edges — groups of 2-4 traces with 2-cell spacing
+      // Seed parallel bundles — tighter spacing (1 cell), bigger groups, longer paths
       function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
-        const bundleSize = 2 + Math.floor(Math.random() * 3) // 2-4 traces
-        const pathLen = 25 + Math.floor(Math.random() * 40)
+        const bundleSize = 3 + Math.floor(Math.random() * 5) // 3-7 traces
+        const pathLen = 40 + Math.floor(Math.random() * 50) // Much longer
         const w = 0.6 + Math.random() * 0.5
         for (let i = 0; i < bundleSize; i++) {
-          const offset = i * 2
-          seedPath(startX + perpDx * offset, startY + perpDy * offset, dir, pathLen, w)
+          seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, w) // 1-cell spacing
         }
       }
 
@@ -115,14 +114,14 @@ export function CircuitBg() {
         seedBundle(cols - 1, y, 2, 0, 1)
       }
 
-      // Single edge traces filling gaps
+      // Single edge traces filling gaps — longer
       for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
-        seedPath(x, 0, 1, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
-        seedPath(x, rows - 1, 3, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+        seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+        seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
       }
       for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
-        seedPath(0, y, 0, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
-        seedPath(cols - 1, y, 2, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+        seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+        seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
       }
 
       // Interior seed bundles
@@ -141,12 +140,12 @@ export function CircuitBg() {
       for (let i = 0; i < interiorSeeds; i++) {
         const x = 3 + Math.floor(Math.random() * (cols - 6))
         const y = 3 + Math.floor(Math.random() * (rows - 6))
-        const dir = Math.floor(Math.random() * 4) // Cardinal only
-        seedPath(x, y, dir, 15 + Math.floor(Math.random() * 35), 0.5 + Math.random() * 0.8)
+        const dir = Math.floor(Math.random() * 4)
+        seedPath(x, y, dir, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
       }
 
       // Round-robin growth: grow all paths one step at a time
-      const STRAIGHTNESS = 0.90 // High straightness but enough turns for PCB look
+      const STRAIGHTNESS = 0.93 // Very straight — long runs with rare clean turns
       const maxSteps = 80
 
       for (let step = 0; step < maxSteps; step++) {

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -1,0 +1,381 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/**
+ * PCB circuit board background using round-robin multi-path growth.
+ * Paths grow simultaneously on a grid, one step at a time, with high
+ * straightness bias. Produces orderly, dense PCB-like patterns reliably.
+ */
+export function CircuitBg() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+
+    interface Pad { x: number; y: number; r: number }
+    interface Glow { x: number; y: number; r: number; ph: number; sp: number }
+    interface Pulse { path: { x: number; y: number }[]; pr: number; sp: number; ln: number; w: number }
+    interface DrawnTrace { pts: { x: number; y: number }[]; w: number }
+
+    let drawnTraces: DrawnTrace[] = []
+    let pads: Pad[] = []
+    let glows: Glow[] = []
+    let pulses: Pulse[] = []
+    let w = 0, h = 0
+
+    function getAccent(): string {
+      return getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
+    }
+    function hexToRgb(hex: string): [number, number, number] {
+      if (!hex.startsWith("#")) return [100, 255, 218]
+      const s = hex.slice(1)
+      if (s.length === 3) return [parseInt(s[0]+s[0],16), parseInt(s[1]+s[1],16), parseInt(s[2]+s[2],16)]
+      return [parseInt(s.slice(0,2),16), parseInt(s.slice(2,4),16), parseInt(s.slice(4,6),16)]
+    }
+
+    // 8 directions: R, D, L, U, DR, DL, UL, UR
+    const DX = [1, 0, -1, 0, 1, -1, -1, 1]
+    const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+
+    function generate() {
+      drawnTraces = []; pads = []; glows = []; pulses = []
+
+      const gridSize = 10 // Balance between density and performance
+      const cols = Math.ceil(w / gridSize)
+      const rows = Math.ceil(h / gridSize)
+      const grid = new Uint8Array(cols * rows) // 0=free, 1=occupied
+
+      const at = (x: number, y: number) => y * cols + x
+      const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
+      const isFree = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+
+      function occupy(x: number, y: number) {
+        if (inBounds(x, y)) grid[at(x, y)] = 1
+      }
+
+      // Check if cell is free (tight packing, no neighbor check)
+      function canPlace(x: number, y: number): boolean {
+        return isFree(x, y)
+      }
+
+      // Active growing paths
+      interface GrowingPath {
+        x: number
+        y: number
+        dir: number // 0-7
+        history: { x: number; y: number }[]
+        maxLen: number
+        alive: boolean
+        width: number
+        isBundle: boolean
+        blockedCount: number // consecutive blocks — die after 2 to prevent zig-zag
+      }
+
+      const paths: GrowingPath[] = []
+
+      // Seed paths from edges and random interior points
+      function seedPath(x: number, y: number, dir: number, maxLen: number, width: number, isBundle = false) {
+        if (!canPlace(x, y)) return
+        occupy(x, y)
+        paths.push({ x, y, dir, history: [{ x, y }], maxLen, alive: true, width, isBundle, blockedCount: 0 })
+      }
+
+      // Seed parallel bundles from edges — groups of 2-4 traces with 2-cell spacing
+      function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
+        const bundleSize = 2 + Math.floor(Math.random() * 3) // 2-4 traces
+        const pathLen = 25 + Math.floor(Math.random() * 40)
+        const w = 0.6 + Math.random() * 0.5
+        for (let i = 0; i < bundleSize; i++) {
+          const offset = i * 2
+          seedPath(startX + perpDx * offset, startY + perpDy * offset, dir, pathLen, w)
+        }
+      }
+
+      // Top edge bundles going down
+      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) {
+        seedBundle(x, 0, 1, 1, 0)
+      }
+      // Bottom edge bundles going up
+      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) {
+        seedBundle(x, rows - 1, 3, 1, 0)
+      }
+      // Left edge bundles going right
+      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) {
+        seedBundle(0, y, 0, 0, 1)
+      }
+      // Right edge bundles going left
+      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) {
+        seedBundle(cols - 1, y, 2, 0, 1)
+      }
+
+      // Single edge traces filling gaps
+      for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
+        seedPath(x, 0, 1, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+        seedPath(x, rows - 1, 3, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+      }
+      for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
+        seedPath(0, y, 0, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+        seedPath(cols - 1, y, 2, 20 + Math.floor(Math.random() * 30), 0.5 + Math.random() * 0.5)
+      }
+
+      // Interior seed bundles
+      const interiorBundles = Math.floor((cols * rows) / 800) + 8
+      for (let i = 0; i < interiorBundles; i++) {
+        const x = 5 + Math.floor(Math.random() * (cols - 10))
+        const y = 5 + Math.floor(Math.random() * (rows - 10))
+        const dir = Math.floor(Math.random() * 4)
+        const perpDx = dir === 1 || dir === 3 ? 1 : 0
+        const perpDy = dir === 0 || dir === 2 ? 1 : 0
+        seedBundle(x, y, dir, perpDx, perpDy)
+      }
+
+      // Interior single seeds
+      const interiorSeeds = Math.floor((cols * rows) / 250) + 15
+      for (let i = 0; i < interiorSeeds; i++) {
+        const x = 3 + Math.floor(Math.random() * (cols - 6))
+        const y = 3 + Math.floor(Math.random() * (rows - 6))
+        const dir = Math.floor(Math.random() * 4) // Cardinal only
+        seedPath(x, y, dir, 15 + Math.floor(Math.random() * 35), 0.5 + Math.random() * 0.8)
+      }
+
+      // Round-robin growth: grow all paths one step at a time
+      const STRAIGHTNESS = 0.90 // High straightness but enough turns for PCB look
+      const maxSteps = 80
+
+      for (let step = 0; step < maxSteps; step++) {
+        // Shuffle path order each step for even distribution
+        const indices = Array.from({ length: paths.length }, (_, i) => i)
+        for (let i = indices.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [indices[i], indices[j]] = [indices[j], indices[i]]
+        }
+
+        let anyAlive = false
+
+        for (const pi of indices) {
+          const p = paths[pi]
+          if (!p.alive) continue
+          if (p.history.length >= p.maxLen) { p.alive = false; continue }
+
+          anyAlive = true
+
+          // Decide direction: straight, 90-degree turn, or short 45-degree chamfer
+          let newDir = p.dir
+          if (Math.random() > STRAIGHTNESS) {
+            if (p.dir < 4) {
+              // Cardinal: 60% chance 90-degree, 40% chance 45-degree chamfer
+              if (Math.random() < 0.6) {
+                newDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
+              } else {
+                newDir = (p.dir + (Math.random() < 0.5 ? 1 : 7)) % 8
+              }
+            } else {
+              // Diagonal: snap back to cardinal
+              const cardinals = [[0, 1], [1, 2], [2, 3], [3, 0]]
+              const opts = cardinals[p.dir - 4]
+              newDir = opts[Math.floor(Math.random() * 2)]
+            }
+          }
+
+          const nx = p.x + DX[newDir]
+          const ny = p.y + DY[newDir]
+
+          if (canPlace(nx, ny)) {
+            occupy(nx, ny)
+            p.x = nx
+            p.y = ny
+            p.dir = newDir
+            p.history.push({ x: nx, y: ny })
+            p.blockedCount = 0
+          } else {
+            p.blockedCount++
+            // Allow one turn attempt, but die on second consecutive block (prevents zig-zag)
+            if (p.blockedCount >= 2) {
+              p.alive = false
+              // Branch at dead end
+              if (p.history.length > 4 && Math.random() < 0.5) {
+                const perpDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
+                seedPath(p.x + DX[perpDir], p.y + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), p.width * 0.8)
+              }
+            } else {
+              // First block: try one 90-degree turn
+              const tryDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
+              const tx = p.x + DX[tryDir]
+              const ty = p.y + DY[tryDir]
+              if (canPlace(tx, ty)) {
+                occupy(tx, ty)
+                p.x = tx
+                p.y = ty
+                p.dir = tryDir
+                p.history.push({ x: tx, y: ty })
+              } else {
+                p.alive = false
+              }
+            }
+          }
+        }
+
+        if (!anyAlive) break
+      }
+
+      // Convert path histories to drawable traces (simplify: collapse consecutive same-direction into line segments)
+      for (const p of paths) {
+        if (p.history.length < 3) continue
+
+        const simplified: { x: number; y: number }[] = [p.history[0]]
+
+        for (let i = 1; i < p.history.length - 1; i++) {
+          const prev = p.history[i - 1]
+          const curr = p.history[i]
+          const next = p.history[i + 1]
+          const dx1 = curr.x - prev.x, dy1 = curr.y - prev.y
+          const dx2 = next.x - curr.x, dy2 = next.y - curr.y
+          // Only keep point if direction changes
+          if (dx1 !== dx2 || dy1 !== dy2) {
+            simplified.push(curr)
+          }
+        }
+        simplified.push(p.history[p.history.length - 1])
+
+        drawnTraces.push({
+          pts: simplified.map(pt => ({ x: pt.x * gridSize, y: pt.y * gridSize })),
+          w: p.width
+        })
+
+        // Terminal pad
+        const last = p.history[p.history.length - 1]
+        pads.push({ x: last.x * gridSize, y: last.y * gridSize, r: 1.5 + Math.random() * 2 })
+
+        // Start pad (sometimes)
+        if (Math.random() < 0.3) {
+          const first = p.history[0]
+          pads.push({ x: first.x * gridSize, y: first.y * gridSize, r: 1.5 + Math.random() * 1.5 })
+        }
+      }
+
+      // Glows at random trace endpoints
+      const glowCount = Math.min(Math.floor(drawnTraces.length / 8), 20)
+      for (let i = 0; i < glowCount; i++) {
+        const tr = drawnTraces[Math.floor(Math.random() * drawnTraces.length)]
+        const p = tr.pts[Math.floor(Math.random() * tr.pts.length)]
+        glows.push({ x: p.x, y: p.y, r: 3 + Math.random() * 5, ph: Math.random() * Math.PI * 2, sp: 0.2 + Math.random() * 0.5 })
+      }
+
+      // Animated pulses
+      if (!reducedMotion && drawnTraces.length > 0) {
+        const pc = Math.min(Math.floor(drawnTraces.length / 8), 8)
+        for (let i = 0; i < pc; i++) {
+          const tr = drawnTraces[Math.floor(Math.random() * drawnTraces.length)]
+          pulses.push({ path: tr.pts, pr: Math.random(), sp: 0.0005 + Math.random() * 0.001, ln: 0.04 + Math.random() * 0.04, w: tr.w })
+        }
+      }
+    }
+
+    function resize() {
+      w = canvas.clientWidth; h = canvas.clientHeight
+      canvas.width = w * dpr; canvas.height = h * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      generate()
+    }
+
+    function draw(time: number) {
+      const accent = getAccent()
+      const [r, g, b] = hexToRgb(accent)
+      ctx.clearRect(0, 0, w, h)
+
+      // Traces
+      for (const tr of drawnTraces) {
+        ctx.beginPath()
+        ctx.moveTo(tr.pts[0].x, tr.pts[0].y)
+        for (let i = 1; i < tr.pts.length; i++) ctx.lineTo(tr.pts[i].x, tr.pts[i].y)
+        ctx.strokeStyle = `rgba(${r},${g},${b},0.13)`
+        ctx.lineWidth = tr.w
+        ctx.lineCap = "round"
+        ctx.lineJoin = "round"
+        ctx.stroke()
+      }
+
+      // Pads
+      for (const p of pads) {
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${r},${g},${b},0.14)`
+        ctx.fill()
+      }
+
+      // Glows
+      const t = time * 0.001
+      for (const gl of glows) {
+        const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * gl.sp + gl.ph) * 0.3
+        const gr = ctx.createRadialGradient(gl.x, gl.y, 0, gl.x, gl.y, gl.r * 5)
+        gr.addColorStop(0, `rgba(${r},${g},${b},${0.2 * pulse})`)
+        gr.addColorStop(0.5, `rgba(${r},${g},${b},${0.06 * pulse})`)
+        gr.addColorStop(1, `rgba(${r},${g},${b},0)`)
+        ctx.beginPath()
+        ctx.arc(gl.x, gl.y, gl.r * 5, 0, Math.PI * 2)
+        ctx.fillStyle = gr
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(gl.x, gl.y, gl.r * 0.5, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${r},${g},${b},${0.4 * pulse})`
+        ctx.fill()
+      }
+
+      // Pulses
+      if (!reducedMotion) {
+        for (const pl of pulses) {
+          if (pl.path.length < 2) continue
+          let tl = 0; const sl: number[] = []
+          for (let i = 1; i < pl.path.length; i++) {
+            const dx = pl.path[i].x - pl.path[i-1].x, dy = pl.path[i].y - pl.path[i-1].y
+            sl.push(Math.sqrt(dx*dx+dy*dy)); tl += sl[sl.length-1]
+          }
+          if (tl < 1) continue
+          const hd = pl.pr * tl, td = Math.max(0, hd - pl.ln * tl)
+          function pt(d: number) {
+            let a = 0
+            for (let i = 0; i < sl.length; i++) {
+              if (a + sl[i] >= d) { const f = (d-a)/sl[i]; return { x: pl.path[i].x+(pl.path[i+1].x-pl.path[i].x)*f, y: pl.path[i].y+(pl.path[i+1].y-pl.path[i].y)*f } }
+              a += sl[i]
+            }
+            return pl.path[pl.path.length-1]
+          }
+          for (let s = 0; s < 10; s++) {
+            const f = s/10, p1 = pt(td+(hd-td)*f), p2 = pt(td+(hd-td)*((s+1)/10))
+            ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y)
+            ctx.strokeStyle = `rgba(${r},${g},${b},${f*f*0.5})`; ctx.lineWidth = pl.w+2; ctx.lineCap = "round"; ctx.stroke()
+          }
+          const head = pt(hd)
+          ctx.save()
+          ctx.shadowColor = `rgba(${r},${g},${b},0.7)`; ctx.shadowBlur = 10
+          ctx.beginPath(); ctx.arc(head.x, head.y, 2.5, 0, Math.PI*2)
+          ctx.fillStyle = `rgba(${r},${g},${b},0.8)`; ctx.fill()
+          ctx.restore()
+          pl.pr += pl.sp
+          if (pl.pr > 1.15) { pl.pr = -pl.ln }
+        }
+      }
+    }
+
+    resize()
+    let rt: ReturnType<typeof setTimeout>
+    const onR = () => { clearTimeout(rt); rt = setTimeout(resize, 300) }
+    window.addEventListener("resize", onR)
+    const obs = new MutationObserver(() => { if (reducedMotion) draw(0) })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
+    if (reducedMotion) { draw(0); return () => { window.removeEventListener("resize", onR); obs.disconnect() } }
+    let fid: number, lt = 0
+    const loop = (t: number) => { if (t-lt >= 33) { draw(t); lt = t }; fid = requestAnimationFrame(loop) }
+    fid = requestAnimationFrame(loop)
+    return () => { cancelAnimationFrame(fid); window.removeEventListener("resize", onR); obs.disconnect() }
+  }, [])
+
+  return <canvas ref={canvasRef} aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full print:hidden" />
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -511,8 +511,9 @@ export function CircuitBg() {
     }
 
     // ── Lifecycle ──
+    // Defer generation so it doesn't block first paint (LCP/TBT)
 
-    resize()
+    const initId = requestAnimationFrame(() => { resize() })
     let rt: ReturnType<typeof setTimeout>
     const onR = () => { clearTimeout(rt); rt = setTimeout(resize, 300) }
     window.addEventListener("resize", onR)
@@ -525,8 +526,7 @@ export function CircuitBg() {
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 
     if (reducedMotion) {
-      draw(0)
-      return () => { window.removeEventListener("resize", onR); obs.disconnect() }
+      return () => { cancelAnimationFrame(initId); window.removeEventListener("resize", onR); obs.disconnect() }
     }
 
     let fid: number, lt = 0
@@ -535,7 +535,7 @@ export function CircuitBg() {
       fid = requestAnimationFrame(loop)
     }
     fid = requestAnimationFrame(loop)
-    return () => { cancelAnimationFrame(fid); window.removeEventListener("resize", onR); obs.disconnect() }
+    return () => { cancelAnimationFrame(initId); cancelAnimationFrame(fid); window.removeEventListener("resize", onR); obs.disconnect() }
   }, [])
 
   return <canvas ref={canvasRef} aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full print:hidden" />

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -59,7 +59,10 @@ export function CircuitBg() {
     let traceColor = ""
     let padColor = ""
 
+    let isLightMode = false
+
     function updateColors() {
+      isLightMode = document.documentElement.getAttribute("data-theme") === "light"
       const accent = getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
       const s = accent.startsWith("#") ? accent.slice(1) : ""
       if (s.length >= 6) {
@@ -71,8 +74,11 @@ export function CircuitBg() {
         cachedG = parseInt(s[1] + s[1], 16)
         cachedB = parseInt(s[2] + s[2], 16)
       }
-      traceColor = `rgba(${cachedR},${cachedG},${cachedB},0.13)`
-      padColor = `rgba(${cachedR},${cachedG},${cachedB},0.14)`
+      // Light mode needs much higher opacity to be visible on light backgrounds
+      const traceAlpha = isLightMode ? 0.18 : 0.13
+      const padAlpha = isLightMode ? 0.22 : 0.14
+      traceColor = `rgba(${cachedR},${cachedG},${cachedB},${traceAlpha})`
+      padColor = `rgba(${cachedR},${cachedG},${cachedB},${padAlpha})`
     }
 
     // Direction vectors
@@ -395,18 +401,19 @@ export function CircuitBg() {
       // ── Glows ──
       const t = time * 0.001
       const r = cachedR, g = cachedG, b = cachedB
+      const glowMult = isLightMode ? 1.8 : 1.0 // Boost glow visibility in light mode
       for (let i = 0; i < glowCount; i++) {
         const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
         const radius = glowR[i] * 5
         const gr = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
-        gr.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse).toFixed(3)})`)
-        gr.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse).toFixed(3)})`)
+        gr.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse * glowMult).toFixed(3)})`)
+        gr.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse * glowMult).toFixed(3)})`)
         gr.addColorStop(1, `rgba(${r},${g},${b},0)`)
         ctx.fillStyle = gr
         ctx.beginPath()
         ctx.arc(glowX[i], glowY[i], radius, 0, 6.2832)
         ctx.fill()
-        ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse).toFixed(3)})`
+        ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse * glowMult).toFixed(3)})`
         ctx.beginPath()
         ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832)
         ctx.fill()
@@ -440,6 +447,7 @@ export function CircuitBg() {
           }
 
           // Draw gradient tail
+          const pulseMult = isLightMode ? 1.6 : 1.0
           ctx.lineCap = "round"
           for (let s = 0; s < 8; s++) {
             const f = s / 8
@@ -448,16 +456,17 @@ export function CircuitBg() {
             ctx.beginPath()
             ctx.moveTo(x1, y1)
             ctx.lineTo(x2, y2)
-            ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5).toFixed(3)})`
+            ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
             ctx.lineWidth = pl.w + 2
             ctx.stroke()
           }
 
-          // Head glow (soft radial gradient instead of expensive shadowBlur)
+          // Head glow
           const [hx, hy] = ptAt(hd)
+          const headAlpha = isLightMode ? 1.0 : 0.8
           const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
-          headGrad.addColorStop(0, `rgba(${r},${g},${b},0.8)`)
-          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},0.3)`)
+          headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
+          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${headAlpha * 0.4})`)
           headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
           ctx.fillStyle = headGrad
           ctx.beginPath()

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef } from "react"
 
 /**
- * PCB circuit board background using round-robin multi-path growth.
- * Paths grow simultaneously on a grid, one step at a time, with high
- * straightness bias. Produces orderly, dense PCB-like patterns reliably.
+ * PCB circuit board background — optimized.
+ *
+ * Generation: round-robin multi-path growth on occupancy grid.
+ * Rendering: batched canvas draws, cached colors, pre-computed pulse geometry.
  */
 export function CircuitBg() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -19,102 +20,121 @@ export function CircuitBg() {
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     const dpr = Math.min(window.devicePixelRatio || 1, 2)
 
-    interface Pad { x: number; y: number; r: number }
-    interface Glow { x: number; y: number; r: number; ph: number; sp: number }
-    interface Pulse { path: { x: number; y: number }[]; pr: number; sp: number; ln: number; w: number }
-    interface DrawnTrace { pts: { x: number; y: number }[]; w: number }
+    // ── Pre-computed data (set once per generate, reused every frame) ──
 
-    let drawnTraces: DrawnTrace[] = []
-    let pads: Pad[] = []
-    let glows: Glow[] = []
-    let pulses: Pulse[] = []
+    // Flat arrays instead of object arrays for traces
+    // Each trace: startIdx into pts array, length, width
+    let traceMeta: Float32Array = new Float32Array(0) // [startIdx, ptCount, width] per trace
+    let tracePts: Float32Array = new Float32Array(0)  // [x, y] flat pairs
+    let traceCount = 0
+
+    let padX: Float32Array = new Float32Array(0)
+    let padY: Float32Array = new Float32Array(0)
+    let padR: Float32Array = new Float32Array(0)
+    let padCount = 0
+
+    let glowX: Float32Array = new Float32Array(0)
+    let glowY: Float32Array = new Float32Array(0)
+    let glowR: Float32Array = new Float32Array(0)
+    let glowPh: Float32Array = new Float32Array(0)
+    let glowSp: Float32Array = new Float32Array(0)
+    let glowCount = 0
+
+    // Pulses with pre-computed segment lengths
+    interface PulseData {
+      pts: Float32Array   // [x,y] pairs
+      segLens: Float32Array
+      totalLen: number
+      pr: number
+      sp: number
+      ln: number
+      w: number
+    }
+    let pulseData: PulseData[] = []
+
     let w = 0, h = 0
 
-    function getAccent(): string {
-      return getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
-    }
-    function hexToRgb(hex: string): [number, number, number] {
-      if (!hex.startsWith("#")) return [100, 255, 218]
-      const s = hex.slice(1)
-      if (s.length === 3) return [parseInt(s[0]+s[0],16), parseInt(s[1]+s[1],16), parseInt(s[2]+s[2],16)]
-      return [parseInt(s.slice(0,2),16), parseInt(s.slice(2,4),16), parseInt(s.slice(4,6),16)]
+    // ── Cached color state ──
+    let cachedR = 100, cachedG = 255, cachedB = 218
+    let traceColor = ""
+    let padColor = ""
+
+    function updateColors() {
+      const accent = getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
+      const s = accent.startsWith("#") ? accent.slice(1) : ""
+      if (s.length >= 6) {
+        cachedR = parseInt(s.slice(0, 2), 16)
+        cachedG = parseInt(s.slice(2, 4), 16)
+        cachedB = parseInt(s.slice(4, 6), 16)
+      } else if (s.length === 3) {
+        cachedR = parseInt(s[0] + s[0], 16)
+        cachedG = parseInt(s[1] + s[1], 16)
+        cachedB = parseInt(s[2] + s[2], 16)
+      }
+      traceColor = `rgba(${cachedR},${cachedG},${cachedB},0.13)`
+      padColor = `rgba(${cachedR},${cachedG},${cachedB},0.14)`
     }
 
-    // 8 directions: R, D, L, U, DR, DL, UL, UR
+    // Direction vectors
     const DX = [1, 0, -1, 0, 1, -1, -1, 1]
     const DY = [0, 1, 0, -1, 1, 1, -1, -1]
 
     function generate() {
-      drawnTraces = []; pads = []; glows = []; pulses = []
-
-      const gridSize = 10 // Balance between density and performance
+      const gridSize = 10
       const cols = Math.ceil(w / gridSize)
       const rows = Math.ceil(h / gridSize)
-      const grid = new Uint8Array(cols * rows) // 0=free, 1=occupied
+      const grid = new Uint8Array(cols * rows)
 
       const at = (x: number, y: number) => y * cols + x
       const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
-      const isFree = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+      const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
 
       function occupy(x: number, y: number) {
         if (inBounds(x, y)) grid[at(x, y)] = 1
       }
 
-      // Check if cell is free (tight packing, no neighbor check)
-      function canPlace(x: number, y: number): boolean {
-        return isFree(x, y)
-      }
+      // Path storage — use flat arrays to reduce GC pressure
+      const MAX_PATHS = 2000
+      const MAX_HISTORY = 100
+      // Per-path state
+      const px = new Int16Array(MAX_PATHS)
+      const py = new Int16Array(MAX_PATHS)
+      const pdir = new Uint8Array(MAX_PATHS)
+      const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
+      const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
+      const phistLen = new Uint16Array(MAX_PATHS)
+      const pmaxLen = new Uint16Array(MAX_PATHS)
+      const palive = new Uint8Array(MAX_PATHS)
+      const pwidth = new Float32Array(MAX_PATHS)
+      const pblocked = new Uint8Array(MAX_PATHS)
+      let pathCount = 0
 
-      // Active growing paths
-      interface GrowingPath {
-        x: number
-        y: number
-        dir: number // 0-7
-        history: { x: number; y: number }[]
-        maxLen: number
-        alive: boolean
-        width: number
-        isBundle: boolean
-        blockedCount: number // consecutive blocks — die after 2 to prevent zig-zag
-      }
-
-      const paths: GrowingPath[] = []
-
-      // Seed paths from edges and random interior points
-      function seedPath(x: number, y: number, dir: number, maxLen: number, width: number, isBundle = false) {
-        if (!canPlace(x, y)) return
+      function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
+        if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
         occupy(x, y)
-        paths.push({ x, y, dir, history: [{ x, y }], maxLen, alive: true, width, isBundle, blockedCount: 0 })
+        const i = pathCount++
+        px[i] = x; py[i] = y; pdir[i] = dir
+        phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
+        phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
+        palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
       }
 
-      // Seed parallel bundles — tighter spacing (1 cell), bigger groups, longer paths
       function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
-        const bundleSize = 3 + Math.floor(Math.random() * 5) // 3-7 traces
-        const pathLen = 40 + Math.floor(Math.random() * 50) // Much longer
-        const w = 0.6 + Math.random() * 0.5
+        const bundleSize = 3 + Math.floor(Math.random() * 5)
+        const pathLen = 40 + Math.floor(Math.random() * 50)
+        const bw = 0.6 + Math.random() * 0.5
         for (let i = 0; i < bundleSize; i++) {
-          seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, w) // 1-cell spacing
+          seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
         }
       }
 
-      // Top edge bundles going down
-      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) {
-        seedBundle(x, 0, 1, 1, 0)
-      }
-      // Bottom edge bundles going up
-      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) {
-        seedBundle(x, rows - 1, 3, 1, 0)
-      }
-      // Left edge bundles going right
-      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) {
-        seedBundle(0, y, 0, 0, 1)
-      }
-      // Right edge bundles going left
-      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) {
-        seedBundle(cols - 1, y, 2, 0, 1)
-      }
+      // Seed from edges
+      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
+      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
+      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
 
-      // Single edge traces filling gaps — longer
+      // Single edge fills
       for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
         seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
         seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
@@ -124,9 +144,9 @@ export function CircuitBg() {
         seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
       }
 
-      // Interior seed bundles
-      const interiorBundles = Math.floor((cols * rows) / 800) + 8
-      for (let i = 0; i < interiorBundles; i++) {
+      // Interior bundles
+      const intBundles = Math.floor((cols * rows) / 800) + 8
+      for (let i = 0; i < intBundles; i++) {
         const x = 5 + Math.floor(Math.random() * (cols - 10))
         const y = 5 + Math.floor(Math.random() * (rows - 10))
         const dir = Math.floor(Math.random() * 4)
@@ -135,87 +155,83 @@ export function CircuitBg() {
         seedBundle(x, y, dir, perpDx, perpDy)
       }
 
-      // Interior single seeds
-      const interiorSeeds = Math.floor((cols * rows) / 250) + 15
-      for (let i = 0; i < interiorSeeds; i++) {
+      // Interior singles
+      const intSeeds = Math.floor((cols * rows) / 250) + 15
+      for (let i = 0; i < intSeeds; i++) {
         const x = 3 + Math.floor(Math.random() * (cols - 6))
         const y = 3 + Math.floor(Math.random() * (rows - 6))
-        const dir = Math.floor(Math.random() * 4)
-        seedPath(x, y, dir, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+        seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
       }
 
-      // Round-robin growth: grow all paths one step at a time
-      const STRAIGHTNESS = 0.93 // Very straight — long runs with rare clean turns
+      // ── Round-robin growth ──
+      const STRAIGHTNESS = 0.93
       const maxSteps = 80
 
+      // Reusable shuffle array
+      const shuffleArr = new Uint16Array(MAX_PATHS)
+
       for (let step = 0; step < maxSteps; step++) {
-        // Shuffle path order each step for even distribution
-        const indices = Array.from({ length: paths.length }, (_, i) => i)
-        for (let i = indices.length - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1));
-          [indices[i], indices[j]] = [indices[j], indices[i]]
+        const n = pathCount
+        for (let i = 0; i < n; i++) shuffleArr[i] = i
+        // Fisher-Yates in-place
+        for (let i = n - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1))
+          const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
         }
 
         let anyAlive = false
 
-        for (const pi of indices) {
-          const p = paths[pi]
-          if (!p.alive) continue
-          if (p.history.length >= p.maxLen) { p.alive = false; continue }
+        for (let si = 0; si < n; si++) {
+          const pi = shuffleArr[si]
+          if (!palive[pi]) continue
+          if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
 
           anyAlive = true
 
-          // Decide direction: straight, 90-degree turn, or short 45-degree chamfer
-          let newDir = p.dir
+          let newDir = pdir[pi]
           if (Math.random() > STRAIGHTNESS) {
-            if (p.dir < 4) {
-              // Cardinal: 60% chance 90-degree, 40% chance 45-degree chamfer
+            if (newDir < 4) {
               if (Math.random() < 0.6) {
-                newDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
+                newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
               } else {
-                newDir = (p.dir + (Math.random() < 0.5 ? 1 : 7)) % 8
+                newDir = (newDir + (Math.random() < 0.5 ? 1 : 7)) % 8
               }
             } else {
-              // Diagonal: snap back to cardinal
               const cardinals = [[0, 1], [1, 2], [2, 3], [3, 0]]
-              const opts = cardinals[p.dir - 4]
+              const opts = cardinals[newDir - 4]
               newDir = opts[Math.floor(Math.random() * 2)]
             }
           }
 
-          const nx = p.x + DX[newDir]
-          const ny = p.y + DY[newDir]
+          const nx = px[pi] + DX[newDir]
+          const ny = py[pi] + DY[newDir]
 
           if (canPlace(nx, ny)) {
             occupy(nx, ny)
-            p.x = nx
-            p.y = ny
-            p.dir = newDir
-            p.history.push({ x: nx, y: ny })
-            p.blockedCount = 0
+            px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
+            const hi = pi * MAX_HISTORY + phistLen[pi]
+            phistX[hi] = nx; phistY[hi] = ny
+            phistLen[pi]++
+            pblocked[pi] = 0
           } else {
-            p.blockedCount++
-            // Allow one turn attempt, but die on second consecutive block (prevents zig-zag)
-            if (p.blockedCount >= 2) {
-              p.alive = false
-              // Branch at dead end
-              if (p.history.length > 4 && Math.random() < 0.5) {
-                const perpDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
-                seedPath(p.x + DX[perpDir], p.y + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), p.width * 0.8)
+            pblocked[pi]++
+            if (pblocked[pi] >= 2) {
+              palive[pi] = 0
+              if (phistLen[pi] > 4 && Math.random() < 0.5) {
+                const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+                seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
               }
             } else {
-              // First block: try one 90-degree turn
-              const tryDir = (p.dir + (Math.random() < 0.5 ? 1 : 3)) % 4
-              const tx = p.x + DX[tryDir]
-              const ty = p.y + DY[tryDir]
+              const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+              const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
               if (canPlace(tx, ty)) {
                 occupy(tx, ty)
-                p.x = tx
-                p.y = ty
-                p.dir = tryDir
-                p.history.push({ x: tx, y: ty })
+                px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
+                const hi = pi * MAX_HISTORY + phistLen[pi]
+                phistX[hi] = tx; phistY[hi] = ty
+                phistLen[pi]++
               } else {
-                p.alive = false
+                palive[pi] = 0
               }
             }
           }
@@ -224,57 +240,120 @@ export function CircuitBg() {
         if (!anyAlive) break
       }
 
-      // Convert path histories to drawable traces (simplify: collapse consecutive same-direction into line segments)
-      for (const p of paths) {
-        if (p.history.length < 3) continue
+      // ── Convert to render data ──
+      // Collect all simplified traces
+      const tempTraces: { pts: number[]; w: number }[] = [] // pts as flat [x,y,x,y,...]
+      const tempPads: { x: number; y: number; r: number }[] = []
 
-        const simplified: { x: number; y: number }[] = [p.history[0]]
+      for (let pi = 0; pi < pathCount; pi++) {
+        const len = phistLen[pi]
+        if (len < 3) continue
+        const base = pi * MAX_HISTORY
 
-        for (let i = 1; i < p.history.length - 1; i++) {
-          const prev = p.history[i - 1]
-          const curr = p.history[i]
-          const next = p.history[i + 1]
-          const dx1 = curr.x - prev.x, dy1 = curr.y - prev.y
-          const dx2 = next.x - curr.x, dy2 = next.y - curr.y
-          // Only keep point if direction changes
+        // Simplify: keep only direction-change points
+        const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
+
+        for (let i = 1; i < len - 1; i++) {
+          const dx1 = phistX[base + i] - phistX[base + i - 1]
+          const dy1 = phistY[base + i] - phistY[base + i - 1]
+          const dx2 = phistX[base + i + 1] - phistX[base + i]
+          const dy2 = phistY[base + i + 1] - phistY[base + i]
           if (dx1 !== dx2 || dy1 !== dy2) {
-            simplified.push(curr)
+            simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
           }
         }
-        simplified.push(p.history[p.history.length - 1])
+        simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
 
-        drawnTraces.push({
-          pts: simplified.map(pt => ({ x: pt.x * gridSize, y: pt.y * gridSize })),
-          w: p.width
-        })
+        if (simplified.length >= 4) {
+          tempTraces.push({ pts: simplified, w: pwidth[pi] })
 
-        // Terminal pad
-        const last = p.history[p.history.length - 1]
-        pads.push({ x: last.x * gridSize, y: last.y * gridSize, r: 1.5 + Math.random() * 2 })
-
-        // Start pad (sometimes)
-        if (Math.random() < 0.3) {
-          const first = p.history[0]
-          pads.push({ x: first.x * gridSize, y: first.y * gridSize, r: 1.5 + Math.random() * 1.5 })
+          // Terminal pad
+          tempPads.push({ x: simplified[simplified.length - 2], y: simplified[simplified.length - 1], r: 1.5 + Math.random() * 2 })
+          if (Math.random() < 0.3) {
+            tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+          }
         }
       }
 
-      // Glows at random trace endpoints
-      const glowCount = Math.min(Math.floor(drawnTraces.length / 8), 20)
+      // Pack into typed arrays
+      traceCount = tempTraces.length
+      let totalPts = 0
+      for (const t of tempTraces) totalPts += t.pts.length
+
+      traceMeta = new Float32Array(traceCount * 3)
+      tracePts = new Float32Array(totalPts)
+      let ptOffset = 0
+      for (let i = 0; i < traceCount; i++) {
+        const t = tempTraces[i]
+        traceMeta[i * 3] = ptOffset
+        traceMeta[i * 3 + 1] = t.pts.length / 2
+        traceMeta[i * 3 + 2] = t.w
+        for (let j = 0; j < t.pts.length; j++) tracePts[ptOffset++] = t.pts[j]
+      }
+
+      padCount = tempPads.length
+      padX = new Float32Array(padCount)
+      padY = new Float32Array(padCount)
+      padR = new Float32Array(padCount)
+      for (let i = 0; i < padCount; i++) {
+        padX[i] = tempPads[i].x; padY[i] = tempPads[i].y; padR[i] = tempPads[i].r
+      }
+
+      // Glows
+      glowCount = Math.min(Math.floor(traceCount / 8), 20)
+      glowX = new Float32Array(glowCount)
+      glowY = new Float32Array(glowCount)
+      glowR = new Float32Array(glowCount)
+      glowPh = new Float32Array(glowCount)
+      glowSp = new Float32Array(glowCount)
       for (let i = 0; i < glowCount; i++) {
-        const tr = drawnTraces[Math.floor(Math.random() * drawnTraces.length)]
-        const p = tr.pts[Math.floor(Math.random() * tr.pts.length)]
-        glows.push({ x: p.x, y: p.y, r: 3 + Math.random() * 5, ph: Math.random() * Math.PI * 2, sp: 0.2 + Math.random() * 0.5 })
+        const ti = Math.floor(Math.random() * traceCount)
+        const startIdx = traceMeta[ti * 3]
+        const ptCount = traceMeta[ti * 3 + 1]
+        const pi = Math.floor(Math.random() * ptCount)
+        glowX[i] = tracePts[startIdx + pi * 2]
+        glowY[i] = tracePts[startIdx + pi * 2 + 1]
+        glowR[i] = 3 + Math.random() * 5
+        glowPh[i] = Math.random() * Math.PI * 2
+        glowSp[i] = 0.2 + Math.random() * 0.5
       }
 
-      // Animated pulses
-      if (!reducedMotion && drawnTraces.length > 0) {
-        const pc = Math.min(Math.floor(drawnTraces.length / 8), 8)
+      // Pulses — pre-compute segment lengths and total length
+      pulseData = []
+      if (!reducedMotion && traceCount > 0) {
+        const pc = Math.min(Math.floor(traceCount / 8), 8)
         for (let i = 0; i < pc; i++) {
-          const tr = drawnTraces[Math.floor(Math.random() * drawnTraces.length)]
-          pulses.push({ path: tr.pts, pr: Math.random(), sp: 0.0005 + Math.random() * 0.001, ln: 0.04 + Math.random() * 0.04, w: tr.w })
+          const ti = Math.floor(Math.random() * traceCount)
+          const startIdx = traceMeta[ti * 3]
+          const ptCount = traceMeta[ti * 3 + 1]
+          if (ptCount < 2) continue
+
+          const pts = new Float32Array(ptCount * 2)
+          for (let j = 0; j < ptCount * 2; j++) pts[j] = tracePts[startIdx + j]
+
+          const segLens = new Float32Array(ptCount - 1)
+          let totalLen = 0
+          for (let j = 0; j < ptCount - 1; j++) {
+            const dx = pts[(j + 1) * 2] - pts[j * 2]
+            const dy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+            const len = Math.sqrt(dx * dx + dy * dy)
+            segLens[j] = len
+            totalLen += len
+          }
+
+          if (totalLen < 10) continue
+
+          pulseData.push({
+            pts, segLens, totalLen,
+            pr: 0, // Start at beginning — no teleporting
+            sp: 0.0005 + Math.random() * 0.001,
+            ln: 0.04 + Math.random() * 0.04,
+            w: traceMeta[ti * 3 + 2],
+          })
         }
       }
+
+      updateColors()
     }
 
     function resize() {
@@ -285,93 +364,137 @@ export function CircuitBg() {
     }
 
     function draw(time: number) {
-      const accent = getAccent()
-      const [r, g, b] = hexToRgb(accent)
       ctx.clearRect(0, 0, w, h)
 
-      // Traces
-      for (const tr of drawnTraces) {
+      // ── Traces (batched by similar width for fewer state changes) ──
+      ctx.strokeStyle = traceColor
+      ctx.lineCap = "round"
+      ctx.lineJoin = "round"
+
+      for (let i = 0; i < traceCount; i++) {
+        const startIdx = traceMeta[i * 3]
+        const ptCount = traceMeta[i * 3 + 1]
+        const tw = traceMeta[i * 3 + 2]
+        ctx.lineWidth = tw
         ctx.beginPath()
-        ctx.moveTo(tr.pts[0].x, tr.pts[0].y)
-        for (let i = 1; i < tr.pts.length; i++) ctx.lineTo(tr.pts[i].x, tr.pts[i].y)
-        ctx.strokeStyle = `rgba(${r},${g},${b},0.13)`
-        ctx.lineWidth = tr.w
-        ctx.lineCap = "round"
-        ctx.lineJoin = "round"
+        ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
+        for (let j = 1; j < ptCount; j++) {
+          ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
+        }
         ctx.stroke()
       }
 
-      // Pads
-      for (const p of pads) {
+      // ── Pads (single fillStyle, batched) ──
+      ctx.fillStyle = padColor
+      for (let i = 0; i < padCount; i++) {
         ctx.beginPath()
-        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2)
-        ctx.fillStyle = `rgba(${r},${g},${b},0.14)`
+        ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832) // 2*PI
         ctx.fill()
       }
 
-      // Glows
+      // ── Glows ──
       const t = time * 0.001
-      for (const gl of glows) {
-        const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * gl.sp + gl.ph) * 0.3
-        const gr = ctx.createRadialGradient(gl.x, gl.y, 0, gl.x, gl.y, gl.r * 5)
-        gr.addColorStop(0, `rgba(${r},${g},${b},${0.2 * pulse})`)
-        gr.addColorStop(0.5, `rgba(${r},${g},${b},${0.06 * pulse})`)
+      const r = cachedR, g = cachedG, b = cachedB
+      for (let i = 0; i < glowCount; i++) {
+        const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
+        const radius = glowR[i] * 5
+        const gr = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
+        gr.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse).toFixed(3)})`)
+        gr.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse).toFixed(3)})`)
         gr.addColorStop(1, `rgba(${r},${g},${b},0)`)
-        ctx.beginPath()
-        ctx.arc(gl.x, gl.y, gl.r * 5, 0, Math.PI * 2)
         ctx.fillStyle = gr
-        ctx.fill()
         ctx.beginPath()
-        ctx.arc(gl.x, gl.y, gl.r * 0.5, 0, Math.PI * 2)
-        ctx.fillStyle = `rgba(${r},${g},${b},${0.4 * pulse})`
+        ctx.arc(glowX[i], glowY[i], radius, 0, 6.2832)
+        ctx.fill()
+        ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse).toFixed(3)})`
+        ctx.beginPath()
+        ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832)
         ctx.fill()
       }
 
-      // Pulses
+      // ── Pulses (pre-computed segment lengths, no teleporting) ──
       if (!reducedMotion) {
-        for (const pl of pulses) {
-          if (pl.path.length < 2) continue
-          let tl = 0; const sl: number[] = []
-          for (let i = 1; i < pl.path.length; i++) {
-            const dx = pl.path[i].x - pl.path[i-1].x, dy = pl.path[i].y - pl.path[i-1].y
-            sl.push(Math.sqrt(dx*dx+dy*dy)); tl += sl[sl.length-1]
-          }
-          if (tl < 1) continue
-          const hd = pl.pr * tl, td = Math.max(0, hd - pl.ln * tl)
-          function pt(d: number) {
+        for (const pl of pulseData) {
+          // Skip if pulse hasn't entered the trace yet
+          if (pl.pr < 0) { pl.pr += pl.sp; continue }
+
+          const hd = pl.pr * pl.totalLen
+          const td = Math.max(0, hd - pl.ln * pl.totalLen)
+
+          // Interpolate point at distance along pre-computed segments
+          function ptAt(d: number): [number, number] {
             let a = 0
-            for (let i = 0; i < sl.length; i++) {
-              if (a + sl[i] >= d) { const f = (d-a)/sl[i]; return { x: pl.path[i].x+(pl.path[i+1].x-pl.path[i].x)*f, y: pl.path[i].y+(pl.path[i+1].y-pl.path[i].y)*f } }
-              a += sl[i]
+            for (let i = 0; i < pl.segLens.length; i++) {
+              if (a + pl.segLens[i] >= d) {
+                const f = (d - a) / pl.segLens[i]
+                const i2 = i * 2
+                return [
+                  pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f,
+                  pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f,
+                ]
+              }
+              a += pl.segLens[i]
             }
-            return pl.path[pl.path.length-1]
+            const last = (pl.segLens.length) * 2
+            return [pl.pts[last], pl.pts[last + 1]]
           }
-          for (let s = 0; s < 10; s++) {
-            const f = s/10, p1 = pt(td+(hd-td)*f), p2 = pt(td+(hd-td)*((s+1)/10))
-            ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y)
-            ctx.strokeStyle = `rgba(${r},${g},${b},${f*f*0.5})`; ctx.lineWidth = pl.w+2; ctx.lineCap = "round"; ctx.stroke()
+
+          // Draw gradient tail
+          ctx.lineCap = "round"
+          for (let s = 0; s < 8; s++) {
+            const f = s / 8
+            const [x1, y1] = ptAt(td + (hd - td) * f)
+            const [x2, y2] = ptAt(td + (hd - td) * ((s + 1) / 8))
+            ctx.beginPath()
+            ctx.moveTo(x1, y1)
+            ctx.lineTo(x2, y2)
+            ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5).toFixed(3)})`
+            ctx.lineWidth = pl.w + 2
+            ctx.stroke()
           }
-          const head = pt(hd)
-          ctx.save()
-          ctx.shadowColor = `rgba(${r},${g},${b},0.7)`; ctx.shadowBlur = 10
-          ctx.beginPath(); ctx.arc(head.x, head.y, 2.5, 0, Math.PI*2)
-          ctx.fillStyle = `rgba(${r},${g},${b},0.8)`; ctx.fill()
-          ctx.restore()
+
+          // Head glow (soft radial gradient instead of expensive shadowBlur)
+          const [hx, hy] = ptAt(hd)
+          const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+          headGrad.addColorStop(0, `rgba(${r},${g},${b},0.8)`)
+          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},0.3)`)
+          headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
+          ctx.fillStyle = headGrad
+          ctx.beginPath()
+          ctx.arc(hx, hy, 8, 0, 6.2832)
+          ctx.fill()
+
+          // Advance pulse
           pl.pr += pl.sp
-          if (pl.pr > 1.15) { pl.pr = -pl.ln }
+          if (pl.pr > 1.05) { pl.pr = -pl.ln * 0.5 } // Brief invisible gap before restart
         }
       }
     }
+
+    // ── Lifecycle ──
 
     resize()
     let rt: ReturnType<typeof setTimeout>
     const onR = () => { clearTimeout(rt); rt = setTimeout(resize, 300) }
     window.addEventListener("resize", onR)
-    const obs = new MutationObserver(() => { if (reducedMotion) draw(0) })
+
+    // Update colors on theme change
+    const obs = new MutationObserver(() => {
+      updateColors()
+      if (reducedMotion) draw(0)
+    })
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
-    if (reducedMotion) { draw(0); return () => { window.removeEventListener("resize", onR); obs.disconnect() } }
+
+    if (reducedMotion) {
+      draw(0)
+      return () => { window.removeEventListener("resize", onR); obs.disconnect() }
+    }
+
     let fid: number, lt = 0
-    const loop = (t: number) => { if (t-lt >= 33) { draw(t); lt = t }; fid = requestAnimationFrame(loop) }
+    const loop = (t: number) => {
+      if (t - lt >= 33) { draw(t); lt = t }
+      fid = requestAnimationFrame(loop)
+    }
     fid = requestAnimationFrame(loop)
     return () => { cancelAnimationFrame(fid); window.removeEventListener("resize", onR); obs.disconnect() }
   }, [])

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useRef } from "react"
 
 /**
- * PCB circuit board background — optimized.
+ * PCB circuit board background.
  *
- * Generation: round-robin multi-path growth on occupancy grid.
+ * Generation runs in a Web Worker (zero main-thread blocking).
  * Rendering: batched canvas draws, cached colors, pre-computed pulse geometry.
  */
 export function CircuitBg() {
@@ -19,29 +19,26 @@ export function CircuitBg() {
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     const dpr = Math.min(window.devicePixelRatio || 1, 2)
 
-    // ── Pre-computed data (set once per generate, reused every frame) ──
+    // ── Render data (received from worker) ──
 
-    // Flat arrays instead of object arrays for traces
-    // Each trace: startIdx into pts array, length, width
-    let traceMeta: Float32Array = new Float32Array(0) // [startIdx, ptCount, width] per trace
-    let tracePts: Float32Array = new Float32Array(0)  // [x, y] flat pairs
+    let traceMeta = new Float32Array(0)
+    let tracePts = new Float32Array(0)
     let traceCount = 0
 
-    let padX: Float32Array = new Float32Array(0)
-    let padY: Float32Array = new Float32Array(0)
-    let padR: Float32Array = new Float32Array(0)
+    let padX = new Float32Array(0)
+    let padY = new Float32Array(0)
+    let padR = new Float32Array(0)
     let padCount = 0
 
-    let glowX: Float32Array = new Float32Array(0)
-    let glowY: Float32Array = new Float32Array(0)
-    let glowR: Float32Array = new Float32Array(0)
-    let glowPh: Float32Array = new Float32Array(0)
-    let glowSp: Float32Array = new Float32Array(0)
+    let glowX = new Float32Array(0)
+    let glowY = new Float32Array(0)
+    let glowR = new Float32Array(0)
+    let glowPh = new Float32Array(0)
+    let glowSp = new Float32Array(0)
     let glowCount = 0
 
-    // Pulses with pre-computed segment lengths
     interface PulseData {
-      pts: Float32Array   // [x,y] pairs
+      pts: Float32Array
       segLens: Float32Array
       totalLen: number
       pr: number
@@ -52,12 +49,13 @@ export function CircuitBg() {
     let pulseData: PulseData[] = []
 
     let w = 0, h = 0
+    let ready = false
 
     // ── Cached color state ──
+
     let cachedR = 100, cachedG = 255, cachedB = 218
     let traceColor = ""
     let padColor = ""
-
     let isLightMode = false
 
     function updateColors() {
@@ -79,297 +77,43 @@ export function CircuitBg() {
       padColor = `rgba(${cachedR},${cachedG},${cachedB},${padAlpha})`
     }
 
-    // Direction vectors
-    const DX = [1, 0, -1, 0, 1, -1, -1, 1]
-    const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+    // ── Worker ──
 
-    function generate() {
-      const gridSize = 10
-      const cols = Math.ceil(w / gridSize)
-      const rows = Math.ceil(h / gridSize)
-      const grid = new Uint8Array(cols * rows)
+    const worker = new Worker(
+      new URL("../workers/circuit-generate.ts", import.meta.url)
+    )
 
-      const at = (x: number, y: number) => y * cols + x
-      const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
-      const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+    let genId = 0
 
-      function occupy(x: number, y: number) {
-        if (inBounds(x, y)) grid[at(x, y)] = 1
-      }
-
-      // Path storage — use flat arrays to reduce GC pressure
-      const MAX_PATHS = 2000
-      const MAX_HISTORY = 100
-      // Per-path state
-      const px = new Int16Array(MAX_PATHS)
-      const py = new Int16Array(MAX_PATHS)
-      const pdir = new Uint8Array(MAX_PATHS)
-      const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
-      const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
-      const phistLen = new Uint16Array(MAX_PATHS)
-      const pmaxLen = new Uint16Array(MAX_PATHS)
-      const palive = new Uint8Array(MAX_PATHS)
-      const pwidth = new Float32Array(MAX_PATHS)
-      const pblocked = new Uint8Array(MAX_PATHS)
-      let pathCount = 0
-
-      function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
-        if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
-        occupy(x, y)
-        const i = pathCount++
-        px[i] = x; py[i] = y; pdir[i] = dir
-        phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
-        phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
-        palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
-      }
-
-      function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
-        const bundleSize = 3 + Math.floor(Math.random() * 5)
-        const pathLen = 40 + Math.floor(Math.random() * 50)
-        const bw = 0.6 + Math.random() * 0.5
-        for (let i = 0; i < bundleSize; i++) {
-          seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
-        }
-      }
-
-      // Seed from edges
-      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
-      for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
-      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
-      for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
-
-      // Single edge fills
-      for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
-        seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-        seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-      }
-      for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
-        seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-        seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-      }
-
-      // Interior bundles
-      const intBundles = Math.floor((cols * rows) / 800) + 8
-      for (let i = 0; i < intBundles; i++) {
-        const x = 5 + Math.floor(Math.random() * (cols - 10))
-        const y = 5 + Math.floor(Math.random() * (rows - 10))
-        const dir = Math.floor(Math.random() * 4)
-        const perpDx = dir === 1 || dir === 3 ? 1 : 0
-        const perpDy = dir === 0 || dir === 2 ? 1 : 0
-        seedBundle(x, y, dir, perpDx, perpDy)
-      }
-
-      // Interior singles
-      const intSeeds = Math.floor((cols * rows) / 250) + 15
-      for (let i = 0; i < intSeeds; i++) {
-        const x = 3 + Math.floor(Math.random() * (cols - 6))
-        const y = 3 + Math.floor(Math.random() * (rows - 6))
-        seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
-      }
-
-      // ── Round-robin growth ──
-      const STRAIGHTNESS = 0.93
-      const maxSteps = 80
-
-      // Reusable shuffle array
-      const shuffleArr = new Uint16Array(MAX_PATHS)
-
-      for (let step = 0; step < maxSteps; step++) {
-        const n = pathCount
-        for (let i = 0; i < n; i++) shuffleArr[i] = i
-        // Fisher-Yates in-place
-        for (let i = n - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1))
-          const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
-        }
-
-        let anyAlive = false
-
-        for (let si = 0; si < n; si++) {
-          const pi = shuffleArr[si]
-          if (!palive[pi]) continue
-          if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
-
-          anyAlive = true
-
-          let newDir = pdir[pi]
-          if (Math.random() > STRAIGHTNESS) {
-            // Cardinal turns only — orthogonal traces like real PCBs
-            newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
-          }
-
-          const nx = px[pi] + DX[newDir]
-          const ny = py[pi] + DY[newDir]
-
-          if (canPlace(nx, ny)) {
-            occupy(nx, ny)
-            px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
-            const hi = pi * MAX_HISTORY + phistLen[pi]
-            phistX[hi] = nx; phistY[hi] = ny
-            phistLen[pi]++
-            pblocked[pi] = 0
-          } else {
-            pblocked[pi]++
-            if (pblocked[pi] >= 2) {
-              palive[pi] = 0
-              if (phistLen[pi] > 4 && Math.random() < 0.5) {
-                const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
-                seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
-              }
-            } else {
-              const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
-              const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
-              if (canPlace(tx, ty)) {
-                occupy(tx, ty)
-                px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
-                const hi = pi * MAX_HISTORY + phistLen[pi]
-                phistX[hi] = tx; phistY[hi] = ty
-                phistLen[pi]++
-              } else {
-                palive[pi] = 0
-              }
-            }
-          }
-        }
-
-        if (!anyAlive) break
-      }
-
-      // ── Convert to render data ──
-      // Collect all simplified traces
-      const tempTraces: { pts: number[]; w: number }[] = [] // pts as flat [x,y,x,y,...]
-      const tempPads: { x: number; y: number; r: number }[] = []
-
-      for (let pi = 0; pi < pathCount; pi++) {
-        const len = phistLen[pi]
-        if (len < 3) continue
-        const base = pi * MAX_HISTORY
-
-        // Simplify: keep only direction-change points
-        const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
-
-        for (let i = 1; i < len - 1; i++) {
-          const dx1 = phistX[base + i] - phistX[base + i - 1]
-          const dy1 = phistY[base + i] - phistY[base + i - 1]
-          const dx2 = phistX[base + i + 1] - phistX[base + i]
-          const dy2 = phistY[base + i + 1] - phistY[base + i]
-          if (dx1 !== dx2 || dy1 !== dy2) {
-            simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
-          }
-        }
-        simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
-
-        if (simplified.length >= 4) {
-          tempTraces.push({ pts: simplified, w: pwidth[pi] })
-
-          // Terminal pad
-          tempPads.push({ x: simplified[simplified.length - 2], y: simplified[simplified.length - 1], r: 1.5 + Math.random() * 2 })
-          if (Math.random() < 0.3) {
-            tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
-          }
-        }
-      }
-
-      // Pack into typed arrays
-      traceCount = tempTraces.length
-      let totalPts = 0
-      for (const t of tempTraces) totalPts += t.pts.length
-
-      traceMeta = new Float32Array(traceCount * 3)
-      tracePts = new Float32Array(totalPts)
-      let ptOffset = 0
-      for (let i = 0; i < traceCount; i++) {
-        const t = tempTraces[i]
-        traceMeta[i * 3] = ptOffset
-        traceMeta[i * 3 + 1] = t.pts.length / 2
-        traceMeta[i * 3 + 2] = t.w
-        for (let j = 0; j < t.pts.length; j++) tracePts[ptOffset++] = t.pts[j]
-      }
-
-      padCount = tempPads.length
-      padX = new Float32Array(padCount)
-      padY = new Float32Array(padCount)
-      padR = new Float32Array(padCount)
-      for (let i = 0; i < padCount; i++) {
-        padX[i] = tempPads[i].x; padY[i] = tempPads[i].y; padR[i] = tempPads[i].r
-      }
-
-      // Glows
-      glowCount = Math.min(Math.floor(traceCount / 8), 20)
-      glowX = new Float32Array(glowCount)
-      glowY = new Float32Array(glowCount)
-      glowR = new Float32Array(glowCount)
-      glowPh = new Float32Array(glowCount)
-      glowSp = new Float32Array(glowCount)
-      for (let i = 0; i < glowCount; i++) {
-        const ti = Math.floor(Math.random() * traceCount)
-        const startIdx = traceMeta[ti * 3]
-        const ptCount = traceMeta[ti * 3 + 1]
-        const pi = Math.floor(Math.random() * ptCount)
-        glowX[i] = tracePts[startIdx + pi * 2]
-        glowY[i] = tracePts[startIdx + pi * 2 + 1]
-        glowR[i] = 3 + Math.random() * 5
-        glowPh[i] = Math.random() * Math.PI * 2
-        glowSp[i] = 0.2 + Math.random() * 0.5
-      }
-
-      // Pulses — pre-compute segment lengths and total length
-      pulseData = []
-      if (!reducedMotion && traceCount > 0) {
-        const pc = Math.min(Math.floor(traceCount / 4), 24)
-        for (let i = 0; i < pc; i++) {
-          const ti = Math.floor(Math.random() * traceCount)
-          const startIdx = traceMeta[ti * 3]
-          const ptCount = traceMeta[ti * 3 + 1]
-          if (ptCount < 2) continue
-
-          const pts = new Float32Array(ptCount * 2)
-          for (let j = 0; j < ptCount * 2; j++) pts[j] = tracePts[startIdx + j]
-
-          const segLens = new Float32Array(ptCount - 1)
-          let totalLen = 0
-          for (let j = 0; j < ptCount - 1; j++) {
-            const dx = pts[(j + 1) * 2] - pts[j * 2]
-            const dy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
-            const len = Math.sqrt(dx * dx + dy * dy)
-            segLens[j] = len
-            totalLen += len
-          }
-
-          if (totalLen < 10) continue
-
-          // Variable speeds: mix of slow, medium, and fast pulses
-          const speedTier = Math.random()
-          const sp = speedTier < 0.3
-            ? 0.0008 + Math.random() * 0.0007   // slow
-            : speedTier < 0.7
-            ? 0.002 + Math.random() * 0.002      // medium
-            : 0.005 + Math.random() * 0.004       // fast
-
-          pulseData.push({
-            pts, segLens, totalLen,
-            pr: Math.random() * (1.0 + sp * 200), // Stagger across lifecycle
-            sp,
-            ln: 0.04 + Math.random() * 0.06,
-            w: traceMeta[ti * 3 + 2],
-          })
-        }
-      }
-
-      updateColors()
-    }
-
-    function resize() {
+    function requestGenerate() {
       w = canvas.clientWidth; h = canvas.clientHeight
       canvas.width = w * dpr; canvas.height = h * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-      generate()
+      genId++
+      worker.postMessage({ w, h, reducedMotion, id: genId })
     }
+
+    worker.onmessage = (e) => {
+      const d = e.data
+      if (d.id !== genId) return // stale result from a previous resize
+
+      traceMeta = d.traceMeta; tracePts = d.tracePts; traceCount = d.traceCount
+      padX = d.padX; padY = d.padY; padR = d.padR; padCount = d.padCount
+      glowX = d.glowX; glowY = d.glowY; glowR = d.glowR
+      glowPh = d.glowPh; glowSp = d.glowSp; glowCount = d.glowCount
+      pulseData = d.pulses
+      ready = true
+      updateColors()
+      if (reducedMotion) draw(0)
+    }
+
+    // ── Draw ──
 
     function draw(time: number) {
       ctx.clearRect(0, 0, w, h)
+      if (!ready) return
 
-      // ── Traces (batched by similar width for fewer state changes) ──
+      // ── Traces ──
       ctx.strokeStyle = traceColor
       ctx.lineCap = "round"
       ctx.lineJoin = "round"
@@ -387,11 +131,11 @@ export function CircuitBg() {
         ctx.stroke()
       }
 
-      // ── Pads (single fillStyle, batched) ──
+      // ── Pads ──
       ctx.fillStyle = padColor
       for (let i = 0; i < padCount; i++) {
         ctx.beginPath()
-        ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832) // 2*PI
+        ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832)
         ctx.fill()
       }
 
@@ -416,26 +160,22 @@ export function CircuitBg() {
         ctx.fill()
       }
 
-      // ── Pulses (gradual grow-in / shrink-out lifecycle) ──
+      // ── Pulses ──
       if (!reducedMotion) {
         for (const pl of pulseData) {
-          // Lifecycle: grow tail in → full length → shrink tail out → restart
           const life = pl.pr < pl.ln
-            ? pl.pr / pl.ln                              // growing in: 0→1
+            ? pl.pr / pl.ln
             : pl.pr > 1.0
-            ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)   // shrinking out: 1→0
-            : 1.0                                         // full length
+            ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
+            : 1.0
 
-          // Advance and reset when fully exited
           pl.pr += pl.sp
           if (life <= 0) { pl.pr = 0; continue }
 
-          // Head clamped to trace end, tail clamped to trace start
           const hd = Math.min(pl.pr, 1.0) * pl.totalLen
           const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
           if (hd - td < 1) continue
 
-          // Interpolate point at distance along pre-computed segments
           function ptAt(d: number): [number, number] {
             let a = 0
             for (let i = 0; i < pl.segLens.length; i++) {
@@ -453,7 +193,6 @@ export function CircuitBg() {
             return [pl.pts[last], pl.pts[last + 1]]
           }
 
-          // Draw gradient tail — opacity scaled by lifecycle
           const pulseMult = (isLightMode ? 0.8 : 0.7) * life
           ctx.lineCap = "round"
           for (let s = 0; s < 8; s++) {
@@ -468,7 +207,6 @@ export function CircuitBg() {
             ctx.stroke()
           }
 
-          // Head glow — also scaled by lifecycle
           const [hx, hy] = ptAt(hd)
           const headAlpha = 0.5 * life
           const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
@@ -483,16 +221,12 @@ export function CircuitBg() {
       }
 
       // ── Content readability vignette ──
-      // Full brilliance at all 4 screen edges, sharp fade into the
-      // center content column so text stays readable.
-      // Light mode uses a gentler fade to keep traces visible in the center.
       const isMobile = w < 768
       const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
       const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
       ctx.globalCompositeOperation = "destination-out"
       const bandFade = ctx.createLinearGradient(0, 0, w, 0)
       if (isLightMode && isMobile) {
-        // Light mobile: fade from edges inward, no full-glory zone
         bandFade.addColorStop(0, `rgba(0,0,0,${fadeEdge})`)
         bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
         bandFade.addColorStop(1, `rgba(0,0,0,${fadeEdge})`)
@@ -511,22 +245,20 @@ export function CircuitBg() {
     }
 
     // ── Lifecycle ──
-    // Defer generation so it doesn't block first paint (LCP/TBT)
 
-    const initId = requestAnimationFrame(() => { resize() })
+    requestGenerate()
     let rt: ReturnType<typeof setTimeout>
-    const onR = () => { clearTimeout(rt); rt = setTimeout(resize, 300) }
+    const onR = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
     window.addEventListener("resize", onR)
 
-    // Update colors on theme change
     const obs = new MutationObserver(() => {
       updateColors()
-      if (reducedMotion) draw(0)
+      if (reducedMotion && ready) draw(0)
     })
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 
     if (reducedMotion) {
-      return () => { cancelAnimationFrame(initId); window.removeEventListener("resize", onR); obs.disconnect() }
+      return () => { worker.terminate(); window.removeEventListener("resize", onR); obs.disconnect() }
     }
 
     let fid: number, lt = 0
@@ -535,7 +267,7 @@ export function CircuitBg() {
       fid = requestAnimationFrame(loop)
     }
     fid = requestAnimationFrame(loop)
-    return () => { cancelAnimationFrame(initId); cancelAnimationFrame(fid); window.removeEventListener("resize", onR); obs.disconnect() }
+    return () => { cancelAnimationFrame(fid); worker.terminate(); window.removeEventListener("resize", onR); obs.disconnect() }
   }, [])
 
   return <canvas ref={canvasRef} aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full print:hidden" />

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -12,10 +12,9 @@ export function CircuitBg() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext("2d")
-    if (!ctx) return
+    const canvas = canvasRef.current!
+    const ctx = canvas.getContext("2d")!
+    if (!canvas || !ctx) return
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     const dpr = Math.min(window.devicePixelRatio || 1, 2)
@@ -74,9 +73,8 @@ export function CircuitBg() {
         cachedG = parseInt(s[1] + s[1], 16)
         cachedB = parseInt(s[2] + s[2], 16)
       }
-      // Light mode needs much higher opacity to be visible on light backgrounds
-      const traceAlpha = isLightMode ? 0.18 : 0.13
-      const padAlpha = isLightMode ? 0.22 : 0.14
+      const traceAlpha = isLightMode ? 0.11 : 0.06
+      const padAlpha = isLightMode ? 0.13 : 0.07
       traceColor = `rgba(${cachedR},${cachedG},${cachedB},${traceAlpha})`
       padColor = `rgba(${cachedR},${cachedG},${cachedB},${padAlpha})`
     }
@@ -196,17 +194,8 @@ export function CircuitBg() {
 
           let newDir = pdir[pi]
           if (Math.random() > STRAIGHTNESS) {
-            if (newDir < 4) {
-              if (Math.random() < 0.6) {
-                newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
-              } else {
-                newDir = (newDir + (Math.random() < 0.5 ? 1 : 7)) % 8
-              }
-            } else {
-              const cardinals = [[0, 1], [1, 2], [2, 3], [3, 0]]
-              const opts = cardinals[newDir - 4]
-              newDir = opts[Math.floor(Math.random() * 2)]
-            }
+            // Cardinal turns only — orthogonal traces like real PCBs
+            newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
           }
 
           const nx = px[pi] + DX[newDir]
@@ -327,7 +316,7 @@ export function CircuitBg() {
       // Pulses — pre-compute segment lengths and total length
       pulseData = []
       if (!reducedMotion && traceCount > 0) {
-        const pc = Math.min(Math.floor(traceCount / 8), 8)
+        const pc = Math.min(Math.floor(traceCount / 4), 24)
         for (let i = 0; i < pc; i++) {
           const ti = Math.floor(Math.random() * traceCount)
           const startIdx = traceMeta[ti * 3]
@@ -349,11 +338,19 @@ export function CircuitBg() {
 
           if (totalLen < 10) continue
 
+          // Variable speeds: mix of slow, medium, and fast pulses
+          const speedTier = Math.random()
+          const sp = speedTier < 0.3
+            ? 0.0008 + Math.random() * 0.0007   // slow
+            : speedTier < 0.7
+            ? 0.002 + Math.random() * 0.002      // medium
+            : 0.005 + Math.random() * 0.004       // fast
+
           pulseData.push({
             pts, segLens, totalLen,
-            pr: 0, // Start at beginning — no teleporting
-            sp: 0.0005 + Math.random() * 0.001,
-            ln: 0.04 + Math.random() * 0.04,
+            pr: Math.random() * (1.0 + sp * 200), // Stagger across lifecycle
+            sp,
+            ln: 0.04 + Math.random() * 0.06,
             w: traceMeta[ti * 3 + 2],
           })
         }
@@ -401,7 +398,7 @@ export function CircuitBg() {
       // ── Glows ──
       const t = time * 0.001
       const r = cachedR, g = cachedG, b = cachedB
-      const glowMult = isLightMode ? 1.8 : 1.0 // Boost glow visibility in light mode
+      const glowMult = isLightMode ? 1.0 : 0.8
       for (let i = 0; i < glowCount; i++) {
         const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
         const radius = glowR[i] * 5
@@ -419,14 +416,24 @@ export function CircuitBg() {
         ctx.fill()
       }
 
-      // ── Pulses (pre-computed segment lengths, no teleporting) ──
+      // ── Pulses (gradual grow-in / shrink-out lifecycle) ──
       if (!reducedMotion) {
         for (const pl of pulseData) {
-          // Skip if pulse hasn't entered the trace yet
-          if (pl.pr < 0) { pl.pr += pl.sp; continue }
+          // Lifecycle: grow tail in → full length → shrink tail out → restart
+          const life = pl.pr < pl.ln
+            ? pl.pr / pl.ln                              // growing in: 0→1
+            : pl.pr > 1.0
+            ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)   // shrinking out: 1→0
+            : 1.0                                         // full length
 
-          const hd = pl.pr * pl.totalLen
-          const td = Math.max(0, hd - pl.ln * pl.totalLen)
+          // Advance and reset when fully exited
+          pl.pr += pl.sp
+          if (life <= 0) { pl.pr = 0; continue }
+
+          // Head clamped to trace end, tail clamped to trace start
+          const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+          const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+          if (hd - td < 1) continue
 
           // Interpolate point at distance along pre-computed segments
           function ptAt(d: number): [number, number] {
@@ -446,8 +453,8 @@ export function CircuitBg() {
             return [pl.pts[last], pl.pts[last + 1]]
           }
 
-          // Draw gradient tail
-          const pulseMult = isLightMode ? 1.6 : 1.0
+          // Draw gradient tail — opacity scaled by lifecycle
+          const pulseMult = (isLightMode ? 0.8 : 0.7) * life
           ctx.lineCap = "round"
           for (let s = 0; s < 8; s++) {
             const f = s / 8
@@ -461,23 +468,46 @@ export function CircuitBg() {
             ctx.stroke()
           }
 
-          // Head glow
+          // Head glow — also scaled by lifecycle
           const [hx, hy] = ptAt(hd)
-          const headAlpha = isLightMode ? 1.0 : 0.8
+          const headAlpha = 0.5 * life
           const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
           headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
-          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${headAlpha * 0.4})`)
+          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
           headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
           ctx.fillStyle = headGrad
           ctx.beginPath()
           ctx.arc(hx, hy, 8, 0, 6.2832)
           ctx.fill()
-
-          // Advance pulse
-          pl.pr += pl.sp
-          if (pl.pr > 1.05) { pl.pr = -pl.ln * 0.5 } // Brief invisible gap before restart
         }
       }
+
+      // ── Content readability vignette ──
+      // Full brilliance at all 4 screen edges, sharp fade into the
+      // center content column so text stays readable.
+      // Light mode uses a gentler fade to keep traces visible in the center.
+      const isMobile = w < 768
+      const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
+      const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
+      ctx.globalCompositeOperation = "destination-out"
+      const bandFade = ctx.createLinearGradient(0, 0, w, 0)
+      if (isLightMode && isMobile) {
+        // Light mobile: fade from edges inward, no full-glory zone
+        bandFade.addColorStop(0, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+        bandFade.addColorStop(1, `rgba(0,0,0,${fadeEdge})`)
+      } else {
+        bandFade.addColorStop(0, "rgba(0,0,0,0)")
+        bandFade.addColorStop(0.1, "rgba(0,0,0,0)")
+        bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+        bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.9, "rgba(0,0,0,0)")
+        bandFade.addColorStop(1, "rgba(0,0,0,0)")
+      }
+      ctx.fillStyle = bandFade
+      ctx.fillRect(0, 0, w, h)
+      ctx.globalCompositeOperation = "source-over"
     }
 
     // ── Lifecycle ──

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -8,7 +8,9 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="rounded-md p-2 text-text-muted transition-colors hover:text-accent print:hidden"
+      className={`rounded-md p-2 transition-colors hover:text-accent print:hidden ${
+        theme === "dark" ? "text-white" : "text-black"
+      }`}
       aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
     >
       {theme === "dark" ? (

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -1,0 +1,312 @@
+/**
+ * Web Worker for PCB circuit board generation.
+ *
+ * Runs the expensive path growth algorithm off the main thread so it
+ * doesn't block first paint or contribute to Total Blocking Time.
+ *
+ * Receives: { w, h, reducedMotion, id }
+ * Returns:  { id, traceCount, traceMeta, tracePts, padCount, padX, padY, padR,
+ *             glowCount, glowX, glowY, glowR, glowPh, glowSp, pulses }
+ *
+ * Large typed arrays are transferred (zero-copy). Pulse data is cloned.
+ */
+
+const DX = [1, 0, -1, 0, 1, -1, -1, 1]
+const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+
+interface PulseResult {
+  pts: Float32Array
+  segLens: Float32Array
+  totalLen: number
+  pr: number
+  sp: number
+  ln: number
+  w: number
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const worker = self as any
+
+worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boolean; id: number }>) => {
+  const { w, h, reducedMotion, id } = e.data
+
+  const gridSize = 10
+  const cols = Math.ceil(w / gridSize)
+  const rows = Math.ceil(h / gridSize)
+  const grid = new Uint8Array(cols * rows)
+
+  const at = (x: number, y: number) => y * cols + x
+  const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
+  const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+
+  function occupy(x: number, y: number) {
+    if (inBounds(x, y)) grid[at(x, y)] = 1
+  }
+
+  // ── Path storage ──
+
+  const MAX_PATHS = 2000
+  const MAX_HISTORY = 100
+  const px = new Int16Array(MAX_PATHS)
+  const py = new Int16Array(MAX_PATHS)
+  const pdir = new Uint8Array(MAX_PATHS)
+  const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistLen = new Uint16Array(MAX_PATHS)
+  const pmaxLen = new Uint16Array(MAX_PATHS)
+  const palive = new Uint8Array(MAX_PATHS)
+  const pwidth = new Float32Array(MAX_PATHS)
+  const pblocked = new Uint8Array(MAX_PATHS)
+  let pathCount = 0
+
+  function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
+    if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
+    occupy(x, y)
+    const i = pathCount++
+    px[i] = x; py[i] = y; pdir[i] = dir
+    phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
+    phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
+    palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
+  }
+
+  function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
+    const bundleSize = 3 + Math.floor(Math.random() * 5)
+    const pathLen = 40 + Math.floor(Math.random() * 50)
+    const bw = 0.6 + Math.random() * 0.5
+    for (let i = 0; i < bundleSize; i++) {
+      seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
+    }
+  }
+
+  // ── Seeding ──
+
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
+
+  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+  for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+
+  const intBundles = Math.floor((cols * rows) / 800) + 8
+  for (let i = 0; i < intBundles; i++) {
+    const x = 5 + Math.floor(Math.random() * (cols - 10))
+    const y = 5 + Math.floor(Math.random() * (rows - 10))
+    const dir = Math.floor(Math.random() * 4)
+    const perpDx = dir === 1 || dir === 3 ? 1 : 0
+    const perpDy = dir === 0 || dir === 2 ? 1 : 0
+    seedBundle(x, y, dir, perpDx, perpDy)
+  }
+
+  const intSeeds = Math.floor((cols * rows) / 250) + 15
+  for (let i = 0; i < intSeeds; i++) {
+    const x = 3 + Math.floor(Math.random() * (cols - 6))
+    const y = 3 + Math.floor(Math.random() * (rows - 6))
+    seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+  }
+
+  // ── Round-robin growth ──
+
+  const STRAIGHTNESS = 0.93
+  const maxSteps = 80
+  const shuffleArr = new Uint16Array(MAX_PATHS)
+
+  for (let step = 0; step < maxSteps; step++) {
+    const n = pathCount
+    for (let i = 0; i < n; i++) shuffleArr[i] = i
+    for (let i = n - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
+    }
+
+    let anyAlive = false
+
+    for (let si = 0; si < n; si++) {
+      const pi = shuffleArr[si]
+      if (!palive[pi]) continue
+      if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
+
+      anyAlive = true
+
+      let newDir = pdir[pi]
+      if (Math.random() > STRAIGHTNESS) {
+        newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
+      }
+
+      const nx = px[pi] + DX[newDir]
+      const ny = py[pi] + DY[newDir]
+
+      if (canPlace(nx, ny)) {
+        occupy(nx, ny)
+        px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
+        const hi = pi * MAX_HISTORY + phistLen[pi]
+        phistX[hi] = nx; phistY[hi] = ny
+        phistLen[pi]++
+        pblocked[pi] = 0
+      } else {
+        pblocked[pi]++
+        if (pblocked[pi] >= 2) {
+          palive[pi] = 0
+          if (phistLen[pi] > 4 && Math.random() < 0.5) {
+            const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+            seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
+          }
+        } else {
+          const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+          const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
+          if (canPlace(tx, ty)) {
+            occupy(tx, ty)
+            px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
+            const hi = pi * MAX_HISTORY + phistLen[pi]
+            phistX[hi] = tx; phistY[hi] = ty
+            phistLen[pi]++
+          } else {
+            palive[pi] = 0
+          }
+        }
+      }
+    }
+
+    if (!anyAlive) break
+  }
+
+  // ── Convert to render data ──
+
+  const tempTraces: { pts: number[]; w: number }[] = []
+  const tempPads: { x: number; y: number; r: number }[] = []
+
+  for (let pi = 0; pi < pathCount; pi++) {
+    const len = phistLen[pi]
+    if (len < 3) continue
+    const base = pi * MAX_HISTORY
+
+    const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
+
+    for (let i = 1; i < len - 1; i++) {
+      const dx1 = phistX[base + i] - phistX[base + i - 1]
+      const dy1 = phistY[base + i] - phistY[base + i - 1]
+      const dx2 = phistX[base + i + 1] - phistX[base + i]
+      const dy2 = phistY[base + i + 1] - phistY[base + i]
+      if (dx1 !== dx2 || dy1 !== dy2) {
+        simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
+      }
+    }
+    simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
+
+    if (simplified.length >= 4) {
+      tempTraces.push({ pts: simplified, w: pwidth[pi] })
+      tempPads.push({ x: simplified[simplified.length - 2], y: simplified[simplified.length - 1], r: 1.5 + Math.random() * 2 })
+      if (Math.random() < 0.3) {
+        tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+      }
+    }
+  }
+
+  // Pack traces
+  const traceCount = tempTraces.length
+  let totalPts = 0
+  for (const t of tempTraces) totalPts += t.pts.length
+
+  const traceMeta = new Float32Array(traceCount * 3)
+  const tracePts = new Float32Array(totalPts)
+  let ptOffset = 0
+  for (let i = 0; i < traceCount; i++) {
+    const t = tempTraces[i]
+    traceMeta[i * 3] = ptOffset
+    traceMeta[i * 3 + 1] = t.pts.length / 2
+    traceMeta[i * 3 + 2] = t.w
+    for (let j = 0; j < t.pts.length; j++) tracePts[ptOffset++] = t.pts[j]
+  }
+
+  // Pack pads
+  const padCount = tempPads.length
+  const padX = new Float32Array(padCount)
+  const padY = new Float32Array(padCount)
+  const padR = new Float32Array(padCount)
+  for (let i = 0; i < padCount; i++) {
+    padX[i] = tempPads[i].x; padY[i] = tempPads[i].y; padR[i] = tempPads[i].r
+  }
+
+  // Pack glows
+  const glowCount = Math.min(Math.floor(traceCount / 8), 20)
+  const glowX = new Float32Array(glowCount)
+  const glowY = new Float32Array(glowCount)
+  const glowR = new Float32Array(glowCount)
+  const glowPh = new Float32Array(glowCount)
+  const glowSp = new Float32Array(glowCount)
+  for (let i = 0; i < glowCount; i++) {
+    const ti = Math.floor(Math.random() * traceCount)
+    const startIdx = traceMeta[ti * 3]
+    const ptC = traceMeta[ti * 3 + 1]
+    const pi = Math.floor(Math.random() * ptC)
+    glowX[i] = tracePts[startIdx + pi * 2]
+    glowY[i] = tracePts[startIdx + pi * 2 + 1]
+    glowR[i] = 3 + Math.random() * 5
+    glowPh[i] = Math.random() * Math.PI * 2
+    glowSp[i] = 0.2 + Math.random() * 0.5
+  }
+
+  // Pack pulses (pts/segLens are cloned, not transferred)
+  const pulses: PulseResult[] = []
+  if (!reducedMotion && traceCount > 0) {
+    const pc = Math.min(Math.floor(traceCount / 4), 24)
+    for (let i = 0; i < pc; i++) {
+      const ti = Math.floor(Math.random() * traceCount)
+      const startIdx = traceMeta[ti * 3]
+      const ptC = traceMeta[ti * 3 + 1]
+      if (ptC < 2) continue
+
+      const pts = new Float32Array(ptC * 2)
+      for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[startIdx + j]
+
+      const segLens = new Float32Array(ptC - 1)
+      let totalLen = 0
+      for (let j = 0; j < ptC - 1; j++) {
+        const dx = pts[(j + 1) * 2] - pts[j * 2]
+        const dy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+        const len = Math.sqrt(dx * dx + dy * dy)
+        segLens[j] = len
+        totalLen += len
+      }
+
+      if (totalLen < 10) continue
+
+      const speedTier = Math.random()
+      const sp = speedTier < 0.3
+        ? 0.0008 + Math.random() * 0.0007
+        : speedTier < 0.7
+        ? 0.002 + Math.random() * 0.002
+        : 0.005 + Math.random() * 0.004
+
+      pulses.push({
+        pts, segLens, totalLen,
+        pr: Math.random() * (1.0 + sp * 200),
+        sp,
+        ln: 0.04 + Math.random() * 0.06,
+        w: traceMeta[ti * 3 + 2],
+      })
+    }
+  }
+
+  // Send result — transfer large arrays for zero-copy
+  const msg = {
+    id, traceCount, traceMeta, tracePts,
+    padCount, padX, padY, padR,
+    glowCount, glowX, glowY, glowR, glowPh, glowSp,
+    pulses,
+  }
+
+  const transfer = [
+    traceMeta.buffer, tracePts.buffer,
+    padX.buffer, padY.buffer, padR.buffer,
+    glowX.buffer, glowY.buffer, glowR.buffer, glowPh.buffer, glowSp.buffer,
+  ]
+
+  worker.postMessage(msg, transfer)
+}


### PR DESCRIPTION
## Summary

- Adds a canvas-based PCB circuit board background behind all site content
- Traces grow via round-robin path planning on an occupancy grid, seeded from edges and interior as bundled parallel lines
- Animated light pulses travel along traces with gradual grow-in/shrink-out lifecycle and variable speeds (3-tier: slow/medium/fast)
- Content vignette using `destination-out` compositing fades traces in the reading zone while keeping full brilliance at the periphery
- Orthogonal traces only (no diagonals) because the result looked better. Curious if anyone else can get a nice result with diagonals.
- Darkened light mode palette for better contrast
- Theme toggle icons: white sun (dark mode), black moon (light mode)

## Performance

- **Web Worker**: Circuit generation (occupancy grid, path growth, typed array packing) runs entirely off the main thread via a dedicated Web Worker. Data is transferred back zero-copy. Main thread TBT contribution: ~0ms.
- **Lazy loading**: Component loaded via `next/dynamic` with `ssr: false`. Not in the initial bundle or SSR output.
- **Typed arrays**: `Float32Array`/`Int16Array` for all trace, pad, glow, and pulse data. ~4x less memory, better cache locality, no GC pressure.
- **30fps cap**: Animation loop skips frames to maintain ~30fps, saving battery.
- **Debounced resize**: 300ms debounce on resize to avoid regeneration storms.
- **Generation ID**: Stale worker results from previous resize events are ignored.
- **Lighthouse mobile**: ~85 (from 85 baseline without circuit). Zero regression.

## Files changed

- `workers/circuit-generate.ts` — Web Worker with all generation logic (310 lines)
- `components/circuit-bg.tsx` — canvas rendering, receives data from worker (230 lines)
- `components/circuit-bg-lazy.tsx` — dynamic import wrapper
- `app/layout.tsx` — integrates `CircuitBgLazy` behind content area
- `app/globals.css` — darker light mode palette
- `components/theme-toggle.tsx` — icon color update

## Test plan

- [x] Dark mode hero: traces visible at edges, clean reading zone
- [x] Light mode hero: traces subtler but present, text fully readable
- [x] Mobile light mode: more aggressive vignette, no full-glory edges
- [x] Mobile dark mode: same as desktop dark mode
- [x] Toggle theme: colors update instantly via MutationObserver
- [x] Resize browser: circuit regenerates after 300ms debounce (via worker)
- [x] Print: canvas hidden via `print:hidden`
- [x] Reduced motion: static circuit, no animation
- [x] Admin routes: no circuit (layout conditionally excludes it)
- [x] Lighthouse mobile: performance score >= 80
