### PR TITLE
Move circuit background to OffscreenCanvas for zero main-thread rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@ body {
   }
 
   @keyframes circuit-tile-scroll {
-    to { transform: translateY(-60%); }
+    to { transform: translateY(-50%); }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@ body {
   }
 
   @keyframes circuit-tile-scroll {
-    to { transform: translateY(-50%); }
+    to { transform: translateY(-20%); }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@ body {
   }
 
   @keyframes circuit-tile-scroll {
-    to { transform: translateY(-20%); }
+    to { transform: translateY(-60%); }
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,21 @@ body {
   font-family: var(--font-body), system-ui, sans-serif;
 }
 
+/* Circuit background scroll-driven tiling animation.
+ * Compositor-driven — zero JS lag on scroll.
+ * Supported: Chrome 115+, Safari 18+, Firefox 110+ */
+@supports (animation-timeline: scroll()) {
+  .circuit-bg-anim {
+    animation: circuit-tile-scroll linear both;
+    animation-timeline: scroll(root);
+    animation-range: 0% 100%;
+  }
+
+  @keyframes circuit-tile-scroll {
+    to { transform: translateY(-50%); }
+  }
+}
+
 /* Prose styles for MDX content */
 .prose-custom h2 {
   font-family: var(--font-display), system-ui, sans-serif;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/components/sidebar"
 import { ChatPanelLazy } from "@/components/chat-panel-lazy"
 import { CursorGlow } from "@/components/cursor-glow"
 import { Analytics } from "@vercel/analytics/react"
+import { CircuitBgLazy } from "@/components/circuit-bg-lazy"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
 import { getPosts } from "@/lib/content"
 import { headers } from "next/headers"
@@ -130,8 +131,9 @@ export default async function RootLayout({
             <>
               <CursorGlow />
               <Sidebar />
-              <div className="pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
-                <div className="mx-auto max-w-[900px] px-6 md:px-12">
+              <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+                <CircuitBgLazy />
+                <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
                   {children}
                 </div>
               </div>

--- a/components/circuit-bg-lazy.tsx
+++ b/components/circuit-bg-lazy.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const CircuitBg = dynamic(
+  () => import("./circuit-bg").then((mod) => mod.CircuitBg),
+  { ssr: false },
+)
+
+export function CircuitBgLazy() {
+  return <CircuitBg />
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -256,7 +256,11 @@ export function CircuitBg() {
         }
       }
 
-      // Horizontal vignette covers full content height
+      // Tile 2: copy tile 1 before applying vignette so both tiles get identical content
+      ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
+
+      // Horizontal vignette applied once across the full canvas so the seam
+      // boundary gets the same treatment as every other row.
       const isMobile = w < 768
       const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
       const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -269,11 +273,8 @@ export function CircuitBg() {
         bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
         bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.9, "rgba(0,0,0,0)"); bandFade.addColorStop(1, "rgba(0,0,0,0)")
       }
-      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h)
+      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h * 2)
       ctx.globalCompositeOperation = "source-over"
-
-      // Tile 2: copy the rendered first tile into the second half of the canvas
-      ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
     }
 
     requestGenerate(true)

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -91,6 +91,7 @@ export function CircuitBg() {
       sp: number
       ln: number
       w: number
+      ti: number
     }
 
     let traceMeta = new Float32Array(0)
@@ -194,10 +195,13 @@ export function CircuitBg() {
           const life = pl.pr < pl.ln ? pl.pr / pl.ln : pl.pr > 1.0 ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln) : 1.0
           pl.pr += pl.sp
           if (pl.pr >= 1.0 + pl.ln) {
-            // Pulse completed — pick a new random trace for the next pass
-            const ti = Math.floor(Math.random() * traceCount)
-            const si = traceMeta[ti * 3], ptC = traceMeta[ti * 3 + 1]
-            if (ptC >= 2) {
+            // Pulse completed — pick a new unoccupied trace for the next pass
+            const occupied = new Set(pulseData.filter(p => p !== pl && p.pr > 0).map(p => p.ti))
+            let ti = 0, ptC = 0, att = 0
+            do { ti = Math.floor(Math.random() * traceCount); ptC = traceMeta[ti * 3 + 1]; att++ }
+            while ((ptC < 2 || occupied.has(ti)) && att < 20)
+            if (ptC >= 2 && !occupied.has(ti)) {
+              const si = traceMeta[ti * 3]
               const pts = new Float32Array(ptC * 2)
               for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[si + j]
               const segLens = new Float32Array(ptC - 1)
@@ -208,7 +212,7 @@ export function CircuitBg() {
               }
               if (tl >= 10) {
                 pl.pts = pts; pl.segLens = segLens; pl.totalLen = tl; pl.w = traceMeta[ti * 3 + 2]
-                pl.ln = 0.04 + Math.random() * 0.06
+                pl.ln = 0.04 + Math.random() * 0.06; pl.ti = ti
                 const st = Math.random()
                 pl.sp = st < 0.3 ? 0.0008 + Math.random() * 0.0007 : st < 0.7 ? 0.002 + Math.random() * 0.002 : 0.005 + Math.random() * 0.004
               }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -3,19 +3,21 @@
 import { useEffect, useRef } from "react"
 
 /**
- * PCB circuit board background — OffscreenCanvas edition.
+ * PCB circuit board background.
  *
- * The canvas is transferred to a dedicated worker on mount. All generation
- * and rendering happen off the main thread. This component only relays
- * config at startup and lightweight resize/theme messages thereafter.
+ * Primary path (modern browsers): OffscreenCanvas transferred to
+ * circuit-worker.ts — generation + rendering + animation loop entirely
+ * off the main thread.
+ *
+ * Fallback path (Safari < 17, older iOS): circuit-generate.ts handles
+ * generation in a worker and posts typed arrays back; rendering runs on
+ * the main thread via requestAnimationFrame.
  */
 export function CircuitBg() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current!
-    if (!canvas.transferControlToOffscreen) return // graceful degradation
-
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     const dpr = Math.min(window.devicePixelRatio || 1, 2)
 
@@ -25,51 +27,230 @@ export function CircuitBg() {
       getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
     const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
 
-    const offscreen = canvas.transferControlToOffscreen()
-    const worker = new Worker(new URL("../workers/circuit-worker.ts", import.meta.url))
+    // Prefer canvas.clientWidth; fall back to window dimensions in case layout
+    // hasn't settled yet (can happen on some mobile browsers at mount time).
+    const cw = canvas.clientWidth || window.innerWidth
+    const ch = canvas.clientHeight || window.innerHeight
 
-    worker.postMessage(
-      {
-        type: "init",
-        canvas: offscreen,
-        w: canvas.clientWidth,
-        h: canvas.clientHeight,
-        dpr,
-        reducedMotion,
-        theme: getTheme(),
-        accent: getAccent(),
-        density: getDensity(),
-      },
-      [offscreen],
-    )
+    // ── Primary path: OffscreenCanvas ──────────────────────────────────────
 
-    // Resize — debounced 300 ms
-    let rt: ReturnType<typeof setTimeout>
-    const onResize = () => {
-      clearTimeout(rt)
-      rt = setTimeout(() => {
-        worker.postMessage({
-          type: "resize",
-          w: canvas.clientWidth,
-          h: canvas.clientHeight,
-          dpr: Math.min(window.devicePixelRatio || 1, 2),
-          density: getDensity(),
-        })
-      }, 300)
+    if (typeof canvas.transferControlToOffscreen === "function") {
+      const offscreen = canvas.transferControlToOffscreen()
+      const worker = new Worker(new URL("../workers/circuit-worker.ts", import.meta.url))
+
+      worker.postMessage(
+        { type: "init", canvas: offscreen, w: cw, h: ch, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
+        [offscreen],
+      )
+
+      let rt: ReturnType<typeof setTimeout>
+      const onResize = () => {
+        clearTimeout(rt)
+        rt = setTimeout(() => {
+          worker.postMessage({
+            type: "resize",
+            w: canvas.clientWidth || window.innerWidth,
+            h: canvas.clientHeight || window.innerHeight,
+            dpr: Math.min(window.devicePixelRatio || 1, 2),
+            density: getDensity(),
+          })
+        }, 300)
+      }
+      window.addEventListener("resize", onResize)
+
+      const obs = new MutationObserver(() => {
+        worker.postMessage({ type: "theme", theme: getTheme(), accent: getAccent() })
+      })
+      obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
+
+      return () => {
+        clearTimeout(rt)
+        window.removeEventListener("resize", onResize)
+        obs.disconnect()
+        worker.terminate()
+      }
     }
+
+    // ── Fallback path: generation worker + main-thread rendering ───────────
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    interface PulseData {
+      pts: Float32Array
+      segLens: Float32Array
+      totalLen: number
+      pr: number
+      sp: number
+      ln: number
+      w: number
+    }
+
+    let traceMeta = new Float32Array(0)
+    let tracePts = new Float32Array(0)
+    let traceCount = 0
+    let padX = new Float32Array(0), padY = new Float32Array(0), padR = new Float32Array(0), padCount = 0
+    let glowX = new Float32Array(0), glowY = new Float32Array(0), glowR = new Float32Array(0)
+    let glowPh = new Float32Array(0), glowSp = new Float32Array(0), glowCount = 0
+    let pulseData: PulseData[] = []
+    let w = 0, h = 0, ready = false
+
+    let cachedR = 100, cachedG = 255, cachedB = 218
+    let traceColor = "", padColor = "", isLightMode = false
+
+    function updateColors() {
+      isLightMode = getTheme() === "light"
+      const accent = getAccent()
+      const s = accent.startsWith("#") ? accent.slice(1) : ""
+      if (s.length >= 6) {
+        cachedR = parseInt(s.slice(0, 2), 16)
+        cachedG = parseInt(s.slice(2, 4), 16)
+        cachedB = parseInt(s.slice(4, 6), 16)
+      } else if (s.length === 3) {
+        cachedR = parseInt(s[0] + s[0], 16)
+        cachedG = parseInt(s[1] + s[1], 16)
+        cachedB = parseInt(s[2] + s[2], 16)
+      }
+      traceColor = `rgba(${cachedR},${cachedG},${cachedB},${isLightMode ? 0.11 : 0.06})`
+      padColor = `rgba(${cachedR},${cachedG},${cachedB},${isLightMode ? 0.13 : 0.07})`
+    }
+
+    const genWorker = new Worker(new URL("../workers/circuit-generate.ts", import.meta.url))
+    let genId = 0
+
+    function requestGenerate() {
+      w = canvas.clientWidth || window.innerWidth
+      h = canvas.clientHeight || window.innerHeight
+      canvas.width = w * dpr; canvas.height = h * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      genId++
+      genWorker.postMessage({ w, h, reducedMotion, density: getDensity(), id: genId })
+    }
+
+    genWorker.onmessage = (e) => {
+      const d = e.data
+      if (d.id !== genId) return
+      traceMeta = d.traceMeta; tracePts = d.tracePts; traceCount = d.traceCount
+      padX = d.padX; padY = d.padY; padR = d.padR; padCount = d.padCount
+      glowX = d.glowX; glowY = d.glowY; glowR = d.glowR
+      glowPh = d.glowPh; glowSp = d.glowSp; glowCount = d.glowCount
+      pulseData = d.pulses
+      ready = true
+      updateColors()
+      if (reducedMotion) draw(0)
+    }
+
+    function draw(time: number) {
+      ctx.clearRect(0, 0, w, h)
+      if (!ready) return
+
+      ctx.strokeStyle = traceColor
+      ctx.lineCap = "round"; ctx.lineJoin = "round"
+      for (let i = 0; i < traceCount; i++) {
+        const startIdx = traceMeta[i * 3], ptCount = traceMeta[i * 3 + 1], tw = traceMeta[i * 3 + 2]
+        ctx.lineWidth = tw
+        ctx.beginPath()
+        ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
+        for (let j = 1; j < ptCount; j++) ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
+        ctx.stroke()
+      }
+
+      ctx.fillStyle = padColor
+      for (let i = 0; i < padCount; i++) { ctx.beginPath(); ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832); ctx.fill() }
+
+      const t = time * 0.001, r = cachedR, g = cachedG, b = cachedB
+      const glowMult = isLightMode ? 1.0 : 0.8
+      for (let i = 0; i < glowCount; i++) {
+        const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
+        const radius = glowR[i] * 5
+        const gr = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
+        gr.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse * glowMult).toFixed(3)})`)
+        gr.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse * glowMult).toFixed(3)})`)
+        gr.addColorStop(1, `rgba(${r},${g},${b},0)`)
+        ctx.fillStyle = gr; ctx.beginPath(); ctx.arc(glowX[i], glowY[i], radius, 0, 6.2832); ctx.fill()
+        ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse * glowMult).toFixed(3)})`
+        ctx.beginPath(); ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832); ctx.fill()
+      }
+
+      if (!reducedMotion) {
+        for (const pl of pulseData) {
+          const life = pl.pr < pl.ln ? pl.pr / pl.ln : pl.pr > 1.0 ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln) : 1.0
+          pl.pr += pl.sp
+          if (life <= 0) { pl.pr = 0; continue }
+          const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+          const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+          if (hd - td < 1) continue
+
+          function ptAt(d: number): [number, number] {
+            let a = 0
+            for (let i = 0; i < pl.segLens.length; i++) {
+              if (a + pl.segLens[i] >= d) {
+                const f = (d - a) / pl.segLens[i], i2 = i * 2
+                return [pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f, pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f]
+              }
+              a += pl.segLens[i]
+            }
+            const last = pl.segLens.length * 2
+            return [pl.pts[last], pl.pts[last + 1]]
+          }
+
+          const pulseMult = (isLightMode ? 0.8 : 0.7) * life
+          ctx.lineCap = "round"
+          for (let s = 0; s < 8; s++) {
+            const f = s / 8
+            const [x1, y1] = ptAt(td + (hd - td) * f), [x2, y2] = ptAt(td + (hd - td) * ((s + 1) / 8))
+            ctx.beginPath(); ctx.moveTo(x1, y1); ctx.lineTo(x2, y2)
+            ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
+            ctx.lineWidth = pl.w + 2; ctx.stroke()
+          }
+          const [hx, hy] = ptAt(hd)
+          const headAlpha = 0.5 * life
+          const hg = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+          hg.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
+          hg.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
+          hg.addColorStop(1, `rgba(${r},${g},${b},0)`)
+          ctx.fillStyle = hg; ctx.beginPath(); ctx.arc(hx, hy, 8, 0, 6.2832); ctx.fill()
+        }
+      }
+
+      const isMobile = w < 768
+      const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
+      const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
+      ctx.globalCompositeOperation = "destination-out"
+      const bandFade = ctx.createLinearGradient(0, 0, w, 0)
+      if (isLightMode && isMobile) {
+        bandFade.addColorStop(0, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`); bandFade.addColorStop(1, `rgba(0,0,0,${fadeEdge})`)
+      } else {
+        bandFade.addColorStop(0, "rgba(0,0,0,0)"); bandFade.addColorStop(0.1, "rgba(0,0,0,0)")
+        bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+        bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.9, "rgba(0,0,0,0)"); bandFade.addColorStop(1, "rgba(0,0,0,0)")
+      }
+      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h)
+      ctx.globalCompositeOperation = "source-over"
+    }
+
+    requestGenerate()
+    let rt: ReturnType<typeof setTimeout>
+    const onResize = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
     window.addEventListener("resize", onResize)
 
-    // Theme changes
-    const obs = new MutationObserver(() => {
-      worker.postMessage({ type: "theme", theme: getTheme(), accent: getAccent() })
-    })
+    const obs = new MutationObserver(() => { updateColors(); if (reducedMotion && ready) draw(0) })
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 
+    if (reducedMotion) {
+      return () => { genWorker.terminate(); window.removeEventListener("resize", onResize); obs.disconnect() }
+    }
+
+    let fid: number, lt = 0
+    const loop = (t: number) => { if (t - lt >= 33) { draw(t); lt = t }; fid = requestAnimationFrame(loop) }
+    fid = requestAnimationFrame(loop)
+
     return () => {
+      cancelAnimationFrame(fid)
       clearTimeout(rt)
+      genWorker.terminate()
       window.removeEventListener("resize", onResize)
       obs.disconnect()
-      worker.terminate()
     }
   }, [])
 

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -25,10 +25,10 @@ export function CircuitBg() {
       (document.documentElement.getAttribute("data-theme") ?? "dark") as "dark" | "light"
     const getAccent = () =>
       getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
-    const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
+    const getDensity = () => (window.innerWidth < 768 ? 0.6 : 1.0)
 
-    // Always use viewport dimensions — canvas is fixed-position, viewport-sized.
-    // Using scroll height caused GPU buffer overruns on mobile (blank canvas).
+    // Canvas is fixed-position, viewport-sized — avoids GPU buffer overruns on mobile.
+    // Circuit is generated for the full page height; scroll offset is applied in the worker.
     const cw = window.innerWidth
     const ch = window.innerHeight
 
@@ -40,9 +40,15 @@ export function CircuitBg() {
       worker.onerror = (e) => console.error("[circuit-worker]", e)
 
       worker.postMessage(
-        { type: "init", canvas: offscreen, w: cw, h: ch, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
+        { type: "init", canvas: offscreen, w: cw, h: ch, pageH: document.body.scrollHeight, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
         [offscreen],
       )
+
+      if (window.scrollY > 0) {
+        worker.postMessage({ type: "scroll", scrollY: window.scrollY })
+      }
+      const onScroll = () => worker.postMessage({ type: "scroll", scrollY: window.scrollY })
+      window.addEventListener("scroll", onScroll, { passive: true })
 
       let rt: ReturnType<typeof setTimeout>
       const onResize = () => {
@@ -52,6 +58,7 @@ export function CircuitBg() {
             type: "resize",
             w: window.innerWidth,
             h: window.innerHeight,
+            pageH: document.body.scrollHeight,
             dpr: Math.min(window.devicePixelRatio || 1, 2),
             density: getDensity(),
           })
@@ -66,6 +73,7 @@ export function CircuitBg() {
 
       return () => {
         clearTimeout(rt)
+        window.removeEventListener("scroll", onScroll)
         window.removeEventListener("resize", onResize)
         obs.disconnect()
         worker.terminate()
@@ -125,7 +133,13 @@ export function CircuitBg() {
       canvas.width = w * dpr; canvas.height = h * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
-      genWorker.postMessage({ w, h, reducedMotion, density: getDensity(), id: genId })
+      genWorker.postMessage({
+        w,
+        h: document.body.scrollHeight,
+        reducedMotion: reducedMotion || w < 768,
+        density: getDensity(),
+        id: genId,
+      })
     }
 
     genWorker.onmessage = (e) => {
@@ -141,9 +155,14 @@ export function CircuitBg() {
       if (reducedMotion) draw(0)
     }
 
+    let currentScrollY = window.scrollY
+
     function draw(time: number) {
       ctx.clearRect(0, 0, w, h)
       if (!ready) return
+
+      ctx.save()
+      ctx.translate(0, -currentScrollY)
 
       ctx.strokeStyle = traceColor
       ctx.lineCap = "round"; ctx.lineJoin = "round"
@@ -173,7 +192,7 @@ export function CircuitBg() {
         ctx.beginPath(); ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832); ctx.fill()
       }
 
-      if (!reducedMotion) {
+      if (!reducedMotion && w >= 768) {
         for (const pl of pulseData) {
           const life = pl.pr < pl.ln ? pl.pr / pl.ln : pl.pr > 1.0 ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln) : 1.0
           pl.pr += pl.sp
@@ -214,6 +233,8 @@ export function CircuitBg() {
         }
       }
 
+      ctx.restore()
+
       const isMobile = w < 768
       const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
       const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -231,6 +252,9 @@ export function CircuitBg() {
     }
 
     requestGenerate()
+    const onScroll2 = () => { currentScrollY = window.scrollY }
+    window.addEventListener("scroll", onScroll2, { passive: true })
+
     let rt: ReturnType<typeof setTimeout>
     const onResize = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
     window.addEventListener("resize", onResize)
@@ -239,7 +263,12 @@ export function CircuitBg() {
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 
     if (reducedMotion) {
-      return () => { genWorker.terminate(); window.removeEventListener("resize", onResize); obs.disconnect() }
+      return () => {
+        genWorker.terminate()
+        window.removeEventListener("scroll", onScroll2)
+        window.removeEventListener("resize", onResize)
+        obs.disconnect()
+      }
     }
 
     let fid: number, lt = 0
@@ -250,6 +279,7 @@ export function CircuitBg() {
       cancelAnimationFrame(fid)
       clearTimeout(rt)
       genWorker.terminate()
+      window.removeEventListener("scroll", onScroll2)
       window.removeEventListener("resize", onResize)
       obs.disconnect()
     }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -27,16 +27,17 @@ export function CircuitBg() {
       getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
     const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
 
-    // Prefer canvas.clientWidth; fall back to window dimensions in case layout
-    // hasn't settled yet (can happen on some mobile browsers at mount time).
-    const cw = canvas.clientWidth || window.innerWidth
-    const ch = canvas.clientHeight || window.innerHeight
+    // Always use viewport dimensions — canvas is fixed-position, viewport-sized.
+    // Using scroll height caused GPU buffer overruns on mobile (blank canvas).
+    const cw = window.innerWidth
+    const ch = window.innerHeight
 
     // ── Primary path: OffscreenCanvas ──────────────────────────────────────
 
     if (typeof canvas.transferControlToOffscreen === "function") {
       const offscreen = canvas.transferControlToOffscreen()
       const worker = new Worker(new URL("../workers/circuit-worker.ts", import.meta.url))
+      worker.onerror = (e) => console.error("[circuit-worker]", e)
 
       worker.postMessage(
         { type: "init", canvas: offscreen, w: cw, h: ch, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
@@ -49,8 +50,8 @@ export function CircuitBg() {
         rt = setTimeout(() => {
           worker.postMessage({
             type: "resize",
-            w: canvas.clientWidth || window.innerWidth,
-            h: canvas.clientHeight || window.innerHeight,
+            w: window.innerWidth,
+            h: window.innerHeight,
             dpr: Math.min(window.devicePixelRatio || 1, 2),
             density: getDensity(),
           })
@@ -119,8 +120,8 @@ export function CircuitBg() {
     let genId = 0
 
     function requestGenerate() {
-      w = canvas.clientWidth || window.innerWidth
-      h = canvas.clientHeight || window.innerHeight
+      w = window.innerWidth
+      h = window.innerHeight
       canvas.width = w * dpr; canvas.height = h * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
@@ -258,7 +259,7 @@ export function CircuitBg() {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 h-full w-full print:hidden"
+      className="pointer-events-none fixed inset-0 -z-10 print:hidden"
     />
   )
 }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -193,7 +193,29 @@ export function CircuitBg() {
         for (const pl of pulseData) {
           const life = pl.pr < pl.ln ? pl.pr / pl.ln : pl.pr > 1.0 ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln) : 1.0
           pl.pr += pl.sp
-          if (life <= 0) { pl.pr = 0; continue }
+          if (pl.pr >= 1.0 + pl.ln) {
+            // Pulse completed — pick a new random trace for the next pass
+            const ti = Math.floor(Math.random() * traceCount)
+            const si = traceMeta[ti * 3], ptC = traceMeta[ti * 3 + 1]
+            if (ptC >= 2) {
+              const pts = new Float32Array(ptC * 2)
+              for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[si + j]
+              const segLens = new Float32Array(ptC - 1)
+              let tl = 0
+              for (let j = 0; j < ptC - 1; j++) {
+                const dx = pts[(j + 1) * 2] - pts[j * 2], dy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+                segLens[j] = Math.sqrt(dx * dx + dy * dy); tl += segLens[j]
+              }
+              if (tl >= 10) {
+                pl.pts = pts; pl.segLens = segLens; pl.totalLen = tl; pl.w = traceMeta[ti * 3 + 2]
+                pl.ln = 0.04 + Math.random() * 0.06
+                const st = Math.random()
+                pl.sp = st < 0.3 ? 0.0008 + Math.random() * 0.0007 : st < 0.7 ? 0.002 + Math.random() * 0.002 : 0.005 + Math.random() * 0.004
+              }
+            }
+            pl.pr = 0; continue
+          }
+          if (life <= 0) continue
           const hd = Math.min(pl.pr, 1.0) * pl.totalLen
           const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
           if (hd - td < 1) continue

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -46,13 +46,17 @@ export function CircuitBg() {
         [offscreen],
       )
 
+      let lastW = cw
       let rt: ReturnType<typeof setTimeout>
       const onResize = () => {
         clearTimeout(rt)
         rt = setTimeout(() => {
+          const newW = window.innerWidth
+          if (newW === lastW) return  // height-only change (mobile toolbar) — skip
+          lastW = newW
           worker.postMessage({
             type: "resize",
-            w: window.innerWidth,
+            w: newW,
             h: window.innerHeight,
             dpr: Math.min(window.devicePixelRatio || 1, 2),
             density: getDensity(),
@@ -96,7 +100,7 @@ export function CircuitBg() {
     let glowX = new Float32Array(0), glowY = new Float32Array(0), glowR = new Float32Array(0)
     let glowPh = new Float32Array(0), glowSp = new Float32Array(0), glowCount = 0
     let pulseData: PulseData[] = []
-    let w = 0, h = 0, ready = false
+    let w = 0, h = 0, ready = false, lastW = 0
 
     let cachedR = 100, cachedG = 255, cachedB = 218
     let traceColor = "", padColor = "", isLightMode = false
@@ -121,8 +125,11 @@ export function CircuitBg() {
     const genWorker = new Worker(new URL("../workers/circuit-generate.ts", import.meta.url))
     let genId = 0
 
-    function requestGenerate() {
-      w = window.innerWidth
+    function requestGenerate(forceRegen = false) {
+      const newW = window.innerWidth
+      if (!forceRegen && newW === lastW && ready) return  // height-only change — skip
+      lastW = newW
+      w = newW
       h = window.innerHeight
       canvas.width = w * dpr; canvas.height = h * 2 * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
@@ -130,7 +137,7 @@ export function CircuitBg() {
       genWorker.postMessage({
         w,
         h,
-        reducedMotion: reducedMotion || w < 768,
+        reducedMotion,
         density: getDensity(),
         id: genId,
       })
@@ -182,7 +189,7 @@ export function CircuitBg() {
         ctx.beginPath(); ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832); ctx.fill()
       }
 
-      if (!reducedMotion && w >= 768) {
+      if (!reducedMotion) {
         for (const pl of pulseData) {
           const life = pl.pr < pl.ln ? pl.pr / pl.ln : pl.pr > 1.0 ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln) : 1.0
           pl.pr += pl.sp
@@ -241,12 +248,27 @@ export function CircuitBg() {
 
       // Copy tile 1 to tile 2 (y = h..2h)
       ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
+
+      // Cross-fade at the tile seam (y = h) to hide the hard edge
+      const fadePx = h * 0.18
+      ctx.globalCompositeOperation = "destination-out"
+      const btmFade = ctx.createLinearGradient(0, h - fadePx, 0, h)
+      btmFade.addColorStop(0, "rgba(0,0,0,0)")
+      btmFade.addColorStop(1, "rgba(0,0,0,1)")
+      ctx.fillStyle = btmFade
+      ctx.fillRect(0, h - fadePx, w, fadePx)
+      const topFade = ctx.createLinearGradient(0, h, 0, h + fadePx)
+      topFade.addColorStop(0, "rgba(0,0,0,1)")
+      topFade.addColorStop(1, "rgba(0,0,0,0)")
+      ctx.fillStyle = topFade
+      ctx.fillRect(0, h, w, fadePx)
+      ctx.globalCompositeOperation = "source-over"
     }
 
-    requestGenerate()
+    requestGenerate(true)
 
     let rt: ReturnType<typeof setTimeout>
-    const onResize = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
+    const onResize = () => { clearTimeout(rt); rt = setTimeout(() => requestGenerate(), 300) }
     window.addEventListener("resize", onResize)
 
     const obs = new MutationObserver(() => { updateColors(); if (reducedMotion && ready) draw(0) })

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -100,7 +100,7 @@ export function CircuitBg() {
     let glowX = new Float32Array(0), glowY = new Float32Array(0), glowR = new Float32Array(0)
     let glowPh = new Float32Array(0), glowSp = new Float32Array(0), glowCount = 0
     let pulseData: PulseData[] = []
-    let w = 0, h = 0, ready = false, lastW = 0
+    let w = 0, h = 0, genH = 0, ready = false, lastW = 0
 
     let cachedR = 100, cachedG = 255, cachedB = 218
     let traceColor = "", padColor = "", isLightMode = false
@@ -131,12 +131,13 @@ export function CircuitBg() {
       lastW = newW
       w = newW
       h = window.innerHeight
+      genH = Math.round(h * 1.5)
       canvas.width = w * dpr; canvas.height = h * 2 * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
       genWorker.postMessage({
         w,
-        h,
+        h: genH,
         reducedMotion,
         density: getDensity(),
         id: genId,
@@ -160,7 +161,7 @@ export function CircuitBg() {
       ctx.clearRect(0, 0, w, h * 2)
       if (!ready) return
 
-      // Draw tile 1 (y = 0..h)
+      // Draw circuit (generated for genH = 1.5 × viewport height)
       ctx.strokeStyle = traceColor
       ctx.lineCap = "round"; ctx.lineJoin = "round"
       for (let i = 0; i < traceCount; i++) {
@@ -230,7 +231,7 @@ export function CircuitBg() {
         }
       }
 
-      // Vignette for tile 1
+      // Horizontal vignette covers full content height
       const isMobile = w < 768
       const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
       const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -243,25 +244,16 @@ export function CircuitBg() {
         bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
         bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.9, "rgba(0,0,0,0)"); bandFade.addColorStop(1, "rgba(0,0,0,0)")
       }
-      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h)
-      ctx.globalCompositeOperation = "source-over"
+      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, genH)
 
-      // Copy tile 1 to tile 2 (y = h..2h)
-      ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
-
-      // Cross-fade at the tile seam (y = h) to hide the hard edge
-      const fadePx = h * 0.18
-      ctx.globalCompositeOperation = "destination-out"
-      const btmFade = ctx.createLinearGradient(0, h - fadePx, 0, h)
+      // Soft bottom fade — circuit dissolves before the canvas edge
+      const fadeStart = h * 0.85
+      const fadeEnd = h * 1.4
+      const btmFade = ctx.createLinearGradient(0, fadeStart, 0, fadeEnd)
       btmFade.addColorStop(0, "rgba(0,0,0,0)")
       btmFade.addColorStop(1, "rgba(0,0,0,1)")
       ctx.fillStyle = btmFade
-      ctx.fillRect(0, h - fadePx, w, fadePx)
-      const topFade = ctx.createLinearGradient(0, h, 0, h + fadePx)
-      topFade.addColorStop(0, "rgba(0,0,0,1)")
-      topFade.addColorStop(1, "rgba(0,0,0,0)")
-      ctx.fillStyle = topFade
-      ctx.fillRect(0, h, w, fadePx)
+      ctx.fillRect(0, fadeStart, w, fadeEnd - fadeStart)
       ctx.globalCompositeOperation = "source-over"
     }
 

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -12,6 +12,10 @@ import { useEffect, useRef } from "react"
  * Fallback path (Safari < 17, older iOS): circuit-generate.ts handles
  * generation in a worker and posts typed arrays back; rendering runs on
  * the main thread via requestAnimationFrame.
+ *
+ * Scroll effect: canvas is 2× viewport height with two identical tiles.
+ * A CSS scroll-driven animation (globals.css .circuit-bg-anim) slides it
+ * from translateY(0) to translateY(-50%) — compositor-driven, zero JS lag.
  */
 export function CircuitBg() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -27,8 +31,6 @@ export function CircuitBg() {
       getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
     const getDensity = () => (window.innerWidth < 768 ? 0.6 : 1.0)
 
-    // Canvas is fixed-position, viewport-sized — avoids GPU buffer overruns on mobile.
-    // Circuit is generated for the full page height; scroll offset is applied in the worker.
     const cw = window.innerWidth
     const ch = window.innerHeight
 
@@ -40,15 +42,9 @@ export function CircuitBg() {
       worker.onerror = (e) => console.error("[circuit-worker]", e)
 
       worker.postMessage(
-        { type: "init", canvas: offscreen, w: cw, h: ch, pageH: document.body.scrollHeight, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
+        { type: "init", canvas: offscreen, w: cw, h: ch, dpr, reducedMotion, theme: getTheme(), accent: getAccent(), density: getDensity() },
         [offscreen],
       )
-
-      if (window.scrollY > 0) {
-        worker.postMessage({ type: "scroll", scrollY: window.scrollY })
-      }
-      const onScroll = () => worker.postMessage({ type: "scroll", scrollY: window.scrollY })
-      window.addEventListener("scroll", onScroll, { passive: true })
 
       let rt: ReturnType<typeof setTimeout>
       const onResize = () => {
@@ -58,7 +54,6 @@ export function CircuitBg() {
             type: "resize",
             w: window.innerWidth,
             h: window.innerHeight,
-            pageH: document.body.scrollHeight,
             dpr: Math.min(window.devicePixelRatio || 1, 2),
             density: getDensity(),
           })
@@ -73,7 +68,6 @@ export function CircuitBg() {
 
       return () => {
         clearTimeout(rt)
-        window.removeEventListener("scroll", onScroll)
         window.removeEventListener("resize", onResize)
         obs.disconnect()
         worker.terminate()
@@ -130,12 +124,12 @@ export function CircuitBg() {
     function requestGenerate() {
       w = window.innerWidth
       h = window.innerHeight
-      canvas.width = w * dpr; canvas.height = h * dpr
+      canvas.width = w * dpr; canvas.height = h * 2 * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
       genWorker.postMessage({
         w,
-        h: document.body.scrollHeight,
+        h,
         reducedMotion: reducedMotion || w < 768,
         density: getDensity(),
         id: genId,
@@ -155,15 +149,11 @@ export function CircuitBg() {
       if (reducedMotion) draw(0)
     }
 
-    let currentScrollY = window.scrollY
-
     function draw(time: number) {
-      ctx.clearRect(0, 0, w, h)
+      ctx.clearRect(0, 0, w, h * 2)
       if (!ready) return
 
-      ctx.save()
-      ctx.translate(0, -currentScrollY)
-
+      // Draw tile 1 (y = 0..h)
       ctx.strokeStyle = traceColor
       ctx.lineCap = "round"; ctx.lineJoin = "round"
       for (let i = 0; i < traceCount; i++) {
@@ -233,8 +223,7 @@ export function CircuitBg() {
         }
       }
 
-      ctx.restore()
-
+      // Vignette for tile 1
       const isMobile = w < 768
       const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
       const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -249,11 +238,12 @@ export function CircuitBg() {
       }
       ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h)
       ctx.globalCompositeOperation = "source-over"
+
+      // Copy tile 1 to tile 2 (y = h..2h)
+      ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
     }
 
     requestGenerate()
-    const onScroll2 = () => { currentScrollY = window.scrollY }
-    window.addEventListener("scroll", onScroll2, { passive: true })
 
     let rt: ReturnType<typeof setTimeout>
     const onResize = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
@@ -265,7 +255,6 @@ export function CircuitBg() {
     if (reducedMotion) {
       return () => {
         genWorker.terminate()
-        window.removeEventListener("scroll", onScroll2)
         window.removeEventListener("resize", onResize)
         obs.disconnect()
       }
@@ -279,7 +268,6 @@ export function CircuitBg() {
       cancelAnimationFrame(fid)
       clearTimeout(rt)
       genWorker.terminate()
-      window.removeEventListener("scroll", onScroll2)
       window.removeEventListener("resize", onResize)
       obs.disconnect()
     }
@@ -289,7 +277,7 @@ export function CircuitBg() {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none fixed inset-0 -z-10 print:hidden"
+      className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[200vh] w-full circuit-bg-anim print:hidden"
     />
   )
 }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -306,7 +306,7 @@ export function CircuitBg() {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[200vh] w-full circuit-bg-anim print:hidden"
+      className="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[200svh] w-full circuit-bg-anim print:hidden"
     />
   )
 }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/**
+ * PCB circuit board background — OffscreenCanvas edition.
+ *
+ * The canvas is transferred to a dedicated worker on mount. All generation
+ * and rendering happen off the main thread. This component only relays
+ * config at startup and lightweight resize/theme messages thereafter.
+ */
+export function CircuitBg() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current!
+    if (!canvas.transferControlToOffscreen) return // graceful degradation
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+
+    const getTheme = () =>
+      (document.documentElement.getAttribute("data-theme") ?? "dark") as "dark" | "light"
+    const getAccent = () =>
+      getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
+    const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
+
+    const offscreen = canvas.transferControlToOffscreen()
+    const worker = new Worker(new URL("../workers/circuit-worker.ts", import.meta.url))
+
+    worker.postMessage(
+      {
+        type: "init",
+        canvas: offscreen,
+        w: canvas.clientWidth,
+        h: canvas.clientHeight,
+        dpr,
+        reducedMotion,
+        theme: getTheme(),
+        accent: getAccent(),
+        density: getDensity(),
+      },
+      [offscreen],
+    )
+
+    // Resize — debounced 300 ms
+    let rt: ReturnType<typeof setTimeout>
+    const onResize = () => {
+      clearTimeout(rt)
+      rt = setTimeout(() => {
+        worker.postMessage({
+          type: "resize",
+          w: canvas.clientWidth,
+          h: canvas.clientHeight,
+          dpr: Math.min(window.devicePixelRatio || 1, 2),
+          density: getDensity(),
+        })
+      }, 300)
+    }
+    window.addEventListener("resize", onResize)
+
+    // Theme changes
+    const obs = new MutationObserver(() => {
+      worker.postMessage({ type: "theme", theme: getTheme(), accent: getAccent() })
+    })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
+
+    return () => {
+      clearTimeout(rt)
+      window.removeEventListener("resize", onResize)
+      obs.disconnect()
+      worker.terminate()
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 h-full w-full print:hidden"
+    />
+  )
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -73,7 +73,7 @@ export function CircuitBg() {
 
     // ── Fallback path: generation worker + main-thread rendering ───────────
 
-    const ctx = canvas.getContext("2d")
+    const ctx = canvas.getContext("2d")!
     if (!ctx) return
 
     interface PulseData {

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -100,7 +100,7 @@ export function CircuitBg() {
     let glowX = new Float32Array(0), glowY = new Float32Array(0), glowR = new Float32Array(0)
     let glowPh = new Float32Array(0), glowSp = new Float32Array(0), glowCount = 0
     let pulseData: PulseData[] = []
-    let w = 0, h = 0, genH = 0, ready = false, lastW = 0
+    let w = 0, h = 0, ready = false, lastW = 0
 
     let cachedR = 100, cachedG = 255, cachedB = 218
     let traceColor = "", padColor = "", isLightMode = false
@@ -131,13 +131,12 @@ export function CircuitBg() {
       lastW = newW
       w = newW
       h = window.innerHeight
-      genH = Math.round(h * 1.5)
       canvas.width = w * dpr; canvas.height = h * 2 * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
       genWorker.postMessage({
         w,
-        h: genH,
+        h,
         reducedMotion,
         density: getDensity(),
         id: genId,
@@ -161,7 +160,7 @@ export function CircuitBg() {
       ctx.clearRect(0, 0, w, h * 2)
       if (!ready) return
 
-      // Draw circuit (generated for genH = 1.5 × viewport height)
+      // Draw tile 1 (one viewport-height tile at y=0)
       ctx.strokeStyle = traceColor
       ctx.lineCap = "round"; ctx.lineJoin = "round"
       for (let i = 0; i < traceCount; i++) {
@@ -244,17 +243,11 @@ export function CircuitBg() {
         bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
         bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`); bandFade.addColorStop(0.9, "rgba(0,0,0,0)"); bandFade.addColorStop(1, "rgba(0,0,0,0)")
       }
-      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, genH)
-
-      // Soft bottom fade — circuit dissolves before the canvas edge
-      const fadeStart = h * 0.85
-      const fadeEnd = h * 1.4
-      const btmFade = ctx.createLinearGradient(0, fadeStart, 0, fadeEnd)
-      btmFade.addColorStop(0, "rgba(0,0,0,0)")
-      btmFade.addColorStop(1, "rgba(0,0,0,1)")
-      ctx.fillStyle = btmFade
-      ctx.fillRect(0, fadeStart, w, fadeEnd - fadeStart)
+      ctx.fillStyle = bandFade; ctx.fillRect(0, 0, w, h)
       ctx.globalCompositeOperation = "source-over"
+
+      // Tile 2: copy the rendered first tile into the second half of the canvas
+      ctx.drawImage(canvas, 0, 0, w * dpr, h * dpr, 0, h, w, h)
     }
 
     requestGenerate(true)

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -77,15 +77,40 @@ worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boole
     }
   }
 
-  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
-  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  // Seam stubs — deterministic vertical traces at top/bottom edges so the
+  // tile connects seamlessly when drawn twice (tiled at y=0 and y=h).
+  const seamRows = Math.max(3, Math.ceil(rows * 0.05))
+  const seamStep = 8
+
+  for (let sx = 4; sx < cols - 4; sx += seamStep) {
+    const sw = 0.5 + ((sx * 3 + 7) % 15) / 30
+
+    if (pathCount < MAX_PATHS) {
+      const pi = pathCount++
+      for (let s = 0; s <= seamRows; s++) {
+        phistX[pi * MAX_HISTORY + s] = sx
+        phistY[pi * MAX_HISTORY + s] = s
+        if (inBounds(sx, s)) grid[at(sx, s)] = 1
+      }
+      phistLen[pi] = seamRows + 1; pwidth[pi] = sw; palive[pi] = 0
+      seedPath(sx, seamRows + 1, 1, 15 + (sx % 5) * 5, sw * 0.9)
+    }
+
+    if (pathCount < MAX_PATHS) {
+      const pi = pathCount++
+      for (let s = 0; s <= seamRows; s++) {
+        phistX[pi * MAX_HISTORY + s] = sx
+        phistY[pi * MAX_HISTORY + s] = rows - 1 - s
+        if (inBounds(sx, rows - 1 - s)) grid[at(sx, rows - 1 - s)] = 1
+      }
+      phistLen[pi] = seamRows + 1; pwidth[pi] = sw; palive[pi] = 0
+      seedPath(sx, rows - 2 - seamRows, 3, 15 + (sx % 5) * 5, sw * 0.9)
+    }
+  }
+
+  // Left/right edge bundles (non-tiling edges — random seeding is fine here)
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
-
-  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
-    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-  }
   for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
     seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
     seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -10,6 +10,8 @@
  *             glowCount, glowX, glowY, glowR, glowPh, glowSp, pulses }
  */
 
+export {}
+
 const DX = [1, 0, -1, 0, 1, -1, -1, 1]
 const DY = [0, 1, 0, -1, 1, 1, -1, -1]
 

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -98,12 +98,14 @@ worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boole
 
     if (pathCount < MAX_PATHS) {
       const pi = pathCount++
+      phistX[pi * MAX_HISTORY] = sx
+      phistY[pi * MAX_HISTORY] = rows  // tile boundary point — clipped to y=h when drawn
       for (let s = 0; s <= seamRows; s++) {
-        phistX[pi * MAX_HISTORY + s] = sx
-        phistY[pi * MAX_HISTORY + s] = rows - 1 - s
+        phistX[pi * MAX_HISTORY + 1 + s] = sx
+        phistY[pi * MAX_HISTORY + 1 + s] = rows - 1 - s
         if (inBounds(sx, rows - 1 - s)) grid[at(sx, rows - 1 - s)] = 1
       }
-      phistLen[pi] = seamRows + 1; pwidth[pi] = sw; palive[pi] = 0
+      phistLen[pi] = seamRows + 2; pwidth[pi] = sw; palive[pi] = 0
       seedPath(sx, rows - 2 - seamRows, 3, 15 + (sx % 5) * 5, sw * 0.9)
     }
   }

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -1,0 +1,299 @@
+/**
+ * Web Worker for PCB circuit board generation (fallback path).
+ *
+ * Used when OffscreenCanvas / transferControlToOffscreen is unavailable
+ * (Safari < 17, older iOS). Generates circuit data off the main thread
+ * and posts typed arrays back; rendering happens on the main thread.
+ *
+ * Receives: { w, h, reducedMotion, density, id }
+ * Returns:  { id, traceCount, traceMeta, tracePts, padCount, padX, padY, padR,
+ *             glowCount, glowX, glowY, glowR, glowPh, glowSp, pulses }
+ */
+
+const DX = [1, 0, -1, 0, 1, -1, -1, 1]
+const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+
+interface PulseResult {
+  pts: Float32Array
+  segLens: Float32Array
+  totalLen: number
+  pr: number
+  sp: number
+  ln: number
+  w: number
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const worker = self as any
+
+worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boolean; density: number; id: number }>) => {
+  const { w, h, reducedMotion, density, id } = e.data
+
+  const gridSize = 10
+  const cols = Math.ceil(w / gridSize)
+  const rows = Math.ceil(h / gridSize)
+  const grid = new Uint8Array(cols * rows)
+
+  const at = (x: number, y: number) => y * cols + x
+  const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
+  const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+
+  function occupy(x: number, y: number) {
+    if (inBounds(x, y)) grid[at(x, y)] = 1
+  }
+
+  const MAX_PATHS = 2000
+  const MAX_HISTORY = 100
+  const px = new Int16Array(MAX_PATHS)
+  const py = new Int16Array(MAX_PATHS)
+  const pdir = new Uint8Array(MAX_PATHS)
+  const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistLen = new Uint16Array(MAX_PATHS)
+  const pmaxLen = new Uint16Array(MAX_PATHS)
+  const palive = new Uint8Array(MAX_PATHS)
+  const pwidth = new Float32Array(MAX_PATHS)
+  const pblocked = new Uint8Array(MAX_PATHS)
+  let pathCount = 0
+
+  function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
+    if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
+    occupy(x, y)
+    const i = pathCount++
+    px[i] = x; py[i] = y; pdir[i] = dir
+    phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
+    phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
+    palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
+  }
+
+  function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
+    const bundleSize = 3 + Math.floor(Math.random() * 5)
+    const pathLen = 40 + Math.floor(Math.random() * 50)
+    const bw = 0.6 + Math.random() * 0.5
+    for (let i = 0; i < bundleSize; i++) {
+      seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
+    }
+  }
+
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
+
+  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+  for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+
+  const intBundles = Math.floor((cols * rows) / 800 * density) + 8
+  for (let i = 0; i < intBundles; i++) {
+    const x = 5 + Math.floor(Math.random() * (cols - 10))
+    const y = 5 + Math.floor(Math.random() * (rows - 10))
+    const dir = Math.floor(Math.random() * 4)
+    const perpDx = dir === 1 || dir === 3 ? 1 : 0
+    const perpDy = dir === 0 || dir === 2 ? 1 : 0
+    seedBundle(x, y, dir, perpDx, perpDy)
+  }
+
+  const intSeeds = Math.floor((cols * rows) / 250 * density) + 15
+  for (let i = 0; i < intSeeds; i++) {
+    const x = 3 + Math.floor(Math.random() * (cols - 6))
+    const y = 3 + Math.floor(Math.random() * (rows - 6))
+    seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+  }
+
+  const STRAIGHTNESS = 0.93
+  const maxSteps = 80
+  const shuffleArr = new Uint16Array(MAX_PATHS)
+
+  for (let step = 0; step < maxSteps; step++) {
+    const n = pathCount
+    for (let i = 0; i < n; i++) shuffleArr[i] = i
+    for (let i = n - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
+    }
+
+    let anyAlive = false
+
+    for (let si = 0; si < n; si++) {
+      const pi = shuffleArr[si]
+      if (!palive[pi]) continue
+      if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
+
+      anyAlive = true
+
+      let newDir = pdir[pi]
+      if (Math.random() > STRAIGHTNESS) {
+        newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
+      }
+
+      const nx = px[pi] + DX[newDir]
+      const ny = py[pi] + DY[newDir]
+
+      if (canPlace(nx, ny)) {
+        occupy(nx, ny)
+        px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
+        const hi = pi * MAX_HISTORY + phistLen[pi]
+        phistX[hi] = nx; phistY[hi] = ny
+        phistLen[pi]++
+        pblocked[pi] = 0
+      } else {
+        pblocked[pi]++
+        if (pblocked[pi] >= 2) {
+          palive[pi] = 0
+          if (phistLen[pi] > 4 && Math.random() < 0.5) {
+            const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+            seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
+          }
+        } else {
+          const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+          const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
+          if (canPlace(tx, ty)) {
+            occupy(tx, ty)
+            px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
+            const hi = pi * MAX_HISTORY + phistLen[pi]
+            phistX[hi] = tx; phistY[hi] = ty
+            phistLen[pi]++
+          } else {
+            palive[pi] = 0
+          }
+        }
+      }
+    }
+
+    if (!anyAlive) break
+  }
+
+  const tempTraces: { pts: number[]; w: number }[] = []
+  const tempPads: { x: number; y: number; r: number }[] = []
+
+  for (let pi = 0; pi < pathCount; pi++) {
+    const len = phistLen[pi]
+    if (len < 3) continue
+    const base = pi * MAX_HISTORY
+
+    const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
+
+    for (let i = 1; i < len - 1; i++) {
+      const dx1 = phistX[base + i] - phistX[base + i - 1]
+      const dy1 = phistY[base + i] - phistY[base + i - 1]
+      const dx2 = phistX[base + i + 1] - phistX[base + i]
+      const dy2 = phistY[base + i + 1] - phistY[base + i]
+      if (dx1 !== dx2 || dy1 !== dy2) {
+        simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
+      }
+    }
+    simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
+
+    if (simplified.length >= 4) {
+      tempTraces.push({ pts: simplified, w: pwidth[pi] })
+      tempPads.push({ x: simplified[simplified.length - 2], y: simplified[simplified.length - 1], r: 1.5 + Math.random() * 2 })
+      if (Math.random() < 0.3) {
+        tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+      }
+    }
+  }
+
+  const traceCount = tempTraces.length
+  let totalPts = 0
+  for (const t of tempTraces) totalPts += t.pts.length
+
+  const traceMeta = new Float32Array(traceCount * 3)
+  const tracePts = new Float32Array(totalPts)
+  let ptOffset = 0
+  for (let i = 0; i < traceCount; i++) {
+    const t = tempTraces[i]
+    traceMeta[i * 3] = ptOffset
+    traceMeta[i * 3 + 1] = t.pts.length / 2
+    traceMeta[i * 3 + 2] = t.w
+    for (let j = 0; j < t.pts.length; j++) tracePts[ptOffset++] = t.pts[j]
+  }
+
+  const padCount = tempPads.length
+  const padX = new Float32Array(padCount)
+  const padY = new Float32Array(padCount)
+  const padR = new Float32Array(padCount)
+  for (let i = 0; i < padCount; i++) {
+    padX[i] = tempPads[i].x; padY[i] = tempPads[i].y; padR[i] = tempPads[i].r
+  }
+
+  const glowCount = Math.min(Math.floor(traceCount / 8), 20)
+  const glowX = new Float32Array(glowCount)
+  const glowY = new Float32Array(glowCount)
+  const glowR = new Float32Array(glowCount)
+  const glowPh = new Float32Array(glowCount)
+  const glowSp = new Float32Array(glowCount)
+  for (let i = 0; i < glowCount; i++) {
+    const ti = Math.floor(Math.random() * traceCount)
+    const startIdx = traceMeta[ti * 3]
+    const ptC = traceMeta[ti * 3 + 1]
+    const pi2 = Math.floor(Math.random() * ptC)
+    glowX[i] = tracePts[startIdx + pi2 * 2]
+    glowY[i] = tracePts[startIdx + pi2 * 2 + 1]
+    glowR[i] = 3 + Math.random() * 5
+    glowPh[i] = Math.random() * Math.PI * 2
+    glowSp[i] = 0.2 + Math.random() * 0.5
+  }
+
+  const pulses: PulseResult[] = []
+  if (!reducedMotion && traceCount > 0) {
+    const pc = Math.min(Math.floor(traceCount / 4), 24)
+    for (let i = 0; i < pc; i++) {
+      const ti = Math.floor(Math.random() * traceCount)
+      const startIdx = traceMeta[ti * 3]
+      const ptC = traceMeta[ti * 3 + 1]
+      if (ptC < 2) continue
+
+      const pts = new Float32Array(ptC * 2)
+      for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[startIdx + j]
+
+      const segLens = new Float32Array(ptC - 1)
+      let totalLen = 0
+      for (let j = 0; j < ptC - 1; j++) {
+        const ddx = pts[(j + 1) * 2] - pts[j * 2]
+        const ddy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+        const slen = Math.sqrt(ddx * ddx + ddy * ddy)
+        segLens[j] = slen
+        totalLen += slen
+      }
+
+      if (totalLen < 10) continue
+
+      const speedTier = Math.random()
+      const sp =
+        speedTier < 0.3
+          ? 0.0008 + Math.random() * 0.0007
+          : speedTier < 0.7
+          ? 0.002 + Math.random() * 0.002
+          : 0.005 + Math.random() * 0.004
+
+      pulses.push({
+        pts, segLens, totalLen,
+        pr: Math.random() * (1.0 + sp * 200),
+        sp,
+        ln: 0.04 + Math.random() * 0.06,
+        w: traceMeta[ti * 3 + 2],
+      })
+    }
+  }
+
+  const msg = {
+    id, traceCount, traceMeta, tracePts,
+    padCount, padX, padY, padR,
+    glowCount, glowX, glowY, glowR, glowPh, glowSp,
+    pulses,
+  }
+
+  const transfer = [
+    traceMeta.buffer, tracePts.buffer,
+    padX.buffer, padY.buffer, padR.buffer,
+    glowX.buffer, glowY.buffer, glowR.buffer, glowPh.buffer, glowSp.buffer,
+  ]
+
+  worker.postMessage(msg, transfer)
+}

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -23,6 +23,7 @@ interface PulseResult {
   sp: number
   ln: number
   w: number
+  ti: number
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -272,11 +273,17 @@ worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boole
   const pulses: PulseResult[] = []
   if (!reducedMotion && traceCount > 0) {
     const pc = Math.min(Math.floor(traceCount / 4), 24)
+    const usedTi = new Set<number>()
     for (let i = 0; i < pc; i++) {
-      const ti = Math.floor(Math.random() * traceCount)
+      let ti = 0, ptC = 0, attempts = 0
+      do {
+        ti = Math.floor(Math.random() * traceCount)
+        ptC = traceMeta[ti * 3 + 1]
+        attempts++
+      } while ((ptC < 2 || usedTi.has(ti)) && attempts < 50)
+      if (ptC < 2 || usedTi.has(ti)) continue
+      usedTi.add(ti)
       const startIdx = traceMeta[ti * 3]
-      const ptC = traceMeta[ti * 3 + 1]
-      if (ptC < 2) continue
 
       const pts = new Float32Array(ptC * 2)
       for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[startIdx + j]
@@ -307,6 +314,7 @@ worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boole
         sp,
         ln: 0.04 + Math.random() * 0.06,
         w: traceMeta[ti * 3 + 2],
+        ti,
       })
     }
   }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -608,7 +608,25 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
     ctx.fill()
   }
 
-  // Content readability vignette (per-tile)
+}
+
+function draw(time: number) {
+  ctx.clearRect(0, 0, w, h * 2)
+  if (!ready) return
+
+  const drawablePulses = computePulseStates()
+
+  // Tile 1 at y=0
+  drawScene(time, drawablePulses)
+
+  // Tile 2 at y=h — same frame state, no double-advancing
+  ctx.save()
+  ctx.translate(0, h)
+  drawScene(time, drawablePulses)
+  ctx.restore()
+
+  // Content readability vignette — applied once across the full canvas so the
+  // seam boundary between tiles gets the same treatment as any other row.
   const isMobile = w < 768
   const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
   const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -628,24 +646,8 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
     bandFade.addColorStop(1, "rgba(0,0,0,0)")
   }
   ctx.fillStyle = bandFade
-  ctx.fillRect(0, 0, w, h)
+  ctx.fillRect(0, 0, w, h * 2)
   ctx.globalCompositeOperation = "source-over"
-}
-
-function draw(time: number) {
-  ctx.clearRect(0, 0, w, h * 2)
-  if (!ready) return
-
-  const drawablePulses = computePulseStates()
-
-  // Tile 1 at y=0
-  drawScene(time, drawablePulses)
-
-  // Tile 2 at y=h — same frame state, no double-advancing
-  ctx.save()
-  ctx.translate(0, h)
-  drawScene(time, drawablePulses)
-  ctx.restore()
 }
 
 // ── Animation loop ─────────────────────────────────────────────────────────

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -182,15 +182,20 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
       seedPath(sx, seamRows + 1, 1, 15 + (sx % 5) * 5, sw * 0.9)
     }
 
-    // Bottom stub: mirror of top — (sx, rows-1) → (sx, rows-1-seamRows), straight north
+    // Bottom stub: (sx, rows) → (sx, rows-1-seamRows), straight north.
+    // The first point at y=rows (one past the last valid grid row) ensures the
+    // trace reaches the exact tile boundary h when drawn — Canvas2D clips it
+    // to y=h, meeting tile 2's top stub at global y=h with no gap.
     if (pathCount < MAX_PATHS) {
       const pi = pathCount++
+      phistX[pi * MAX_HISTORY] = sx
+      phistY[pi * MAX_HISTORY] = rows  // tile boundary (rows*gridSize >= h)
       for (let s = 0; s <= seamRows; s++) {
-        phistX[pi * MAX_HISTORY + s] = sx
-        phistY[pi * MAX_HISTORY + s] = rows - 1 - s
+        phistX[pi * MAX_HISTORY + 1 + s] = sx
+        phistY[pi * MAX_HISTORY + 1 + s] = rows - 1 - s
         if (inBounds(sx, rows - 1 - s)) grid[at(sx, rows - 1 - s)] = 1
       }
-      phistLen[pi] = seamRows + 1
+      phistLen[pi] = seamRows + 2
       pwidth[pi] = sw
       palive[pi] = 0
       seedPath(sx, rows - 2 - seamRows, 3, 15 + (sx % 5) * 5, sw * 0.9)
@@ -442,6 +447,47 @@ function ptAt(pl: PulseData, d: number): [number, number] {
   return [pl.pts[last], pl.pts[last + 1]]
 }
 
+// Re-assign a pulse to a new random trace so each cycle looks different.
+function resamplePulse(pl: PulseData) {
+  if (traceCount === 0) return
+  let ti = 0, ptC = 0, attempts = 0
+  do {
+    ti = Math.floor(Math.random() * traceCount)
+    ptC = traceMeta[ti * 3 + 1]
+    attempts++
+  } while (ptC < 2 && attempts < 10)
+  if (ptC < 2) return
+
+  const startIdx = traceMeta[ti * 3]
+  const pts = new Float32Array(ptC * 2)
+  for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[startIdx + j]
+
+  const segLens = new Float32Array(ptC - 1)
+  let totalLen = 0
+  for (let j = 0; j < ptC - 1; j++) {
+    const ddx = pts[(j + 1) * 2] - pts[j * 2]
+    const ddy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+    const slen = Math.sqrt(ddx * ddx + ddy * ddy)
+    segLens[j] = slen
+    totalLen += slen
+  }
+  if (totalLen < 10) return
+
+  const speedTier = Math.random()
+  pl.sp =
+    speedTier < 0.3
+      ? 0.0008 + Math.random() * 0.0007
+      : speedTier < 0.7
+      ? 0.002 + Math.random() * 0.002
+      : 0.005 + Math.random() * 0.004
+
+  pl.pts = pts
+  pl.segLens = segLens
+  pl.totalLen = totalLen
+  pl.w = traceMeta[ti * 3 + 2]
+  pl.ln = 0.04 + Math.random() * 0.06
+}
+
 // Advance pulse positions once per frame and return drawable states.
 // Separating update from draw allows drawScene to be called twice per frame
 // (once per tile) without double-advancing the animation.
@@ -456,7 +502,15 @@ function computePulseStates(): DrawablePulse[] {
         ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
         : 1.0
     pl.pr += pl.sp
-    if (life <= 0) { pl.pr = 0; continue }
+    // Pulse completed its journey — reset to start a new pass on a fresh trace.
+    // Must NOT reset inside `life <= 0` because pr=0 also gives life=0,
+    // which would trap the pulse in an infinite reset loop.
+    if (pl.pr >= 1.0 + pl.ln) {
+      pl.pr = 0
+      resamplePulse(pl)
+      continue
+    }
+    if (life <= 0) continue  // still in the initial fade-in ramp (pr: 0 → ln)
     const hd = Math.min(pl.pr, 1.0) * pl.totalLen
     const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
     if (hd - td < 1) continue

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -333,9 +333,9 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
     gsp[i] = 0.2 + Math.random() * 0.5
   }
 
-  // Pack pulses (desktop only)
+  // Pack pulses
   const pulses: PulseData[] = []
-  if (!rm && gw >= 768 && tc > 0) {
+  if (!rm && tc > 0) {
     const numPulses = Math.min(Math.floor(tc / 4), 24)
     for (let i = 0; i < numPulses; i++) {
       const ti = Math.floor(Math.random() * tc)
@@ -409,7 +409,7 @@ function ptAt(pl: PulseData, d: number): [number, number] {
 // Separating update from draw allows drawScene to be called twice per frame
 // (once per tile) without double-advancing the animation.
 function computePulseStates(): DrawablePulse[] {
-  if (reducedMotion || w < 768) return []
+  if (reducedMotion) return []
   const result: DrawablePulse[] = []
   for (const pl of pulseData) {
     const life =
@@ -546,6 +546,22 @@ function draw(time: number) {
   ctx.translate(0, h)
   drawScene(time, drawablePulses)
   ctx.restore()
+
+  // Cross-fade at the tile seam (y = h) to hide the hard edge.
+  // Fades tile 1 out before the seam and tile 2 in after it.
+  const fadePx = h * 0.18
+  ctx.globalCompositeOperation = "destination-out"
+  const btmFade = ctx.createLinearGradient(0, h - fadePx, 0, h)
+  btmFade.addColorStop(0, "rgba(0,0,0,0)")
+  btmFade.addColorStop(1, "rgba(0,0,0,1)")
+  ctx.fillStyle = btmFade
+  ctx.fillRect(0, h - fadePx, w, fadePx)
+  const topFade = ctx.createLinearGradient(0, h, 0, h + fadePx)
+  topFade.addColorStop(0, "rgba(0,0,0,1)")
+  topFade.addColorStop(1, "rgba(0,0,0,0)")
+  ctx.fillStyle = topFade
+  ctx.fillRect(0, h, w, fadePx)
+  ctx.globalCompositeOperation = "source-over"
 }
 
 // ── Animation loop ─────────────────────────────────────────────────────────

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -11,6 +11,8 @@
  *   { type: 'theme',  theme, accent }
  */
 
+export {}
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 interface PulseData {

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -28,6 +28,7 @@ interface PulseData {
   sp: number
   ln: number
   w: number
+  ti: number
 }
 
 interface DrawablePulse {
@@ -375,15 +376,21 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
     gsp[i] = 0.2 + Math.random() * 0.5
   }
 
-  // Pack pulses
+  // Pack pulses — one per unique trace so no two pulses share the same wire
   const pulses: PulseData[] = []
   if (!rm && tc > 0) {
     const numPulses = Math.min(Math.floor(tc / 4), 24)
+    const usedTi = new Set<number>()
     for (let i = 0; i < numPulses; i++) {
-      const ti = Math.floor(Math.random() * tc)
+      let ti = 0, ptC = 0, attempts = 0
+      do {
+        ti = Math.floor(Math.random() * tc)
+        ptC = tm[ti * 3 + 1]
+        attempts++
+      } while ((ptC < 2 || usedTi.has(ti)) && attempts < 50)
+      if (ptC < 2 || usedTi.has(ti)) continue
+      usedTi.add(ti)
       const startIdx = tm[ti * 3]
-      const ptC = tm[ti * 3 + 1]
-      if (ptC < 2) continue
 
       const pts = new Float32Array(ptC * 2)
       for (let j = 0; j < ptC * 2; j++) pts[j] = tp[startIdx + j]
@@ -416,6 +423,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
         sp,
         ln: 0.04 + Math.random() * 0.06,
         w: tm[ti * 3 + 2],
+        ti,
       })
     }
   }
@@ -447,15 +455,16 @@ function ptAt(pl: PulseData, d: number): [number, number] {
   return [pl.pts[last], pl.pts[last + 1]]
 }
 
-// Re-assign a pulse to a new random trace so each cycle looks different.
+// Re-assign a pulse to a new random unoccupied trace so each cycle looks different.
 function resamplePulse(pl: PulseData) {
   if (traceCount === 0) return
+  const occupied = new Set(pulseData.filter(p => p !== pl && p.pr > 0).map(p => p.ti))
   let ti = 0, ptC = 0, attempts = 0
   do {
     ti = Math.floor(Math.random() * traceCount)
     ptC = traceMeta[ti * 3 + 1]
     attempts++
-  } while (ptC < 2 && attempts < 10)
+  } while ((ptC < 2 || occupied.has(ti)) && attempts < 20)
   if (ptC < 2) return
 
   const startIdx = traceMeta[ti * 3]
@@ -486,6 +495,7 @@ function resamplePulse(pl: PulseData) {
   pl.totalLen = totalLen
   pl.w = traceMeta[ti * 3 + 2]
   pl.ln = 0.04 + Math.random() * 0.06
+  pl.ti = ti
 }
 
 // Advance pulse positions once per frame and return drawable states.

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -1,0 +1,574 @@
+/**
+ * Combined OffscreenCanvas worker for the PCB circuit background.
+ *
+ * Handles both circuit generation and continuous animation entirely off the
+ * main thread. The main thread transfers the canvas once and only sends
+ * lightweight resize/theme messages thereafter.
+ *
+ * Protocol (main → worker):
+ *   { type: 'init',   canvas: OffscreenCanvas, w, h, dpr, reducedMotion, theme, accent, density }
+ *   { type: 'resize', w, h, dpr, density }
+ *   { type: 'theme',  theme, accent }
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface PulseData {
+  pts: Float32Array
+  segLens: Float32Array
+  totalLen: number
+  pr: number
+  sp: number
+  ln: number
+  w: number
+}
+
+type Theme = "dark" | "light"
+
+// ── Module-level state ─────────────────────────────────────────────────────
+
+let offscreen: OffscreenCanvas
+let ctx: OffscreenCanvasRenderingContext2D
+
+let traceMeta = new Float32Array(0)
+let tracePts = new Float32Array(0)
+let traceCount = 0
+
+let padX = new Float32Array(0)
+let padY = new Float32Array(0)
+let padR = new Float32Array(0)
+let padCount = 0
+
+let glowX = new Float32Array(0)
+let glowY = new Float32Array(0)
+let glowR = new Float32Array(0)
+let glowPh = new Float32Array(0)
+let glowSp = new Float32Array(0)
+let glowCount = 0
+
+let pulseData: PulseData[] = []
+
+let w = 0
+let h = 0
+let dpr = 1
+let reducedMotion = false
+let ready = false
+
+// Color cache
+let cachedR = 100
+let cachedG = 255
+let cachedB = 218
+let traceColor = ""
+let padColor = ""
+let isLightMode = false
+
+// Animation
+let animTimer: ReturnType<typeof setInterval> | null = null
+
+// ── Color helpers ──────────────────────────────────────────────────────────
+
+function applyAccent(accent: string, theme: Theme) {
+  isLightMode = theme === "light"
+  const s = accent.startsWith("#") ? accent.slice(1) : ""
+  if (s.length >= 6) {
+    cachedR = parseInt(s.slice(0, 2), 16)
+    cachedG = parseInt(s.slice(2, 4), 16)
+    cachedB = parseInt(s.slice(4, 6), 16)
+  } else if (s.length === 3) {
+    cachedR = parseInt(s[0] + s[0], 16)
+    cachedG = parseInt(s[1] + s[1], 16)
+    cachedB = parseInt(s[2] + s[2], 16)
+  }
+  const traceAlpha = isLightMode ? 0.11 : 0.06
+  const padAlpha = isLightMode ? 0.13 : 0.07
+  traceColor = `rgba(${cachedR},${cachedG},${cachedB},${traceAlpha})`
+  padColor = `rgba(${cachedR},${cachedG},${cachedB},${padAlpha})`
+}
+
+// ── Generation ─────────────────────────────────────────────────────────────
+
+const DX = [1, 0, -1, 0, 1, -1, -1, 1]
+const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+
+function generate(gw: number, gh: number, rm: boolean, density: number) {
+  const gridSize = 10
+  const cols = Math.ceil(gw / gridSize)
+  const rows = Math.ceil(gh / gridSize)
+  const grid = new Uint8Array(cols * rows)
+
+  const at = (x: number, y: number) => y * cols + x
+  const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
+  const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+
+  function occupy(x: number, y: number) {
+    if (inBounds(x, y)) grid[at(x, y)] = 1
+  }
+
+  // ── Path storage ──
+
+  const MAX_PATHS = 2000
+  const MAX_HISTORY = 100
+  const px = new Int16Array(MAX_PATHS)
+  const py = new Int16Array(MAX_PATHS)
+  const pdir = new Uint8Array(MAX_PATHS)
+  const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistLen = new Uint16Array(MAX_PATHS)
+  const pmaxLen = new Uint16Array(MAX_PATHS)
+  const palive = new Uint8Array(MAX_PATHS)
+  const pwidth = new Float32Array(MAX_PATHS)
+  const pblocked = new Uint8Array(MAX_PATHS)
+  let pathCount = 0
+
+  function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
+    if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
+    occupy(x, y)
+    const i = pathCount++
+    px[i] = x; py[i] = y; pdir[i] = dir
+    phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
+    phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
+    palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
+  }
+
+  function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
+    const bundleSize = 3 + Math.floor(Math.random() * 5)
+    const pathLen = 40 + Math.floor(Math.random() * 50)
+    const bw = 0.6 + Math.random() * 0.5
+    for (let i = 0; i < bundleSize; i++) {
+      seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
+    }
+  }
+
+  // ── Seeding ──
+
+  // Edge bundles (not density-scaled — keep edges full at all viewport sizes)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
+
+  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+  for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+
+  // Interior seeds (density-scaled)
+  const intBundles = Math.floor((cols * rows) / 800 * density) + 8
+  for (let i = 0; i < intBundles; i++) {
+    const x = 5 + Math.floor(Math.random() * (cols - 10))
+    const y = 5 + Math.floor(Math.random() * (rows - 10))
+    const dir = Math.floor(Math.random() * 4)
+    const perpDx = dir === 1 || dir === 3 ? 1 : 0
+    const perpDy = dir === 0 || dir === 2 ? 1 : 0
+    seedBundle(x, y, dir, perpDx, perpDy)
+  }
+
+  const intSeeds = Math.floor((cols * rows) / 250 * density) + 15
+  for (let i = 0; i < intSeeds; i++) {
+    const x = 3 + Math.floor(Math.random() * (cols - 6))
+    const y = 3 + Math.floor(Math.random() * (rows - 6))
+    seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+  }
+
+  // ── Round-robin growth ──
+
+  const STRAIGHTNESS = 0.93
+  const maxSteps = 80
+  const shuffleArr = new Uint16Array(MAX_PATHS)
+
+  for (let step = 0; step < maxSteps; step++) {
+    const n = pathCount
+    for (let i = 0; i < n; i++) shuffleArr[i] = i
+    for (let i = n - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
+    }
+
+    let anyAlive = false
+
+    for (let si = 0; si < n; si++) {
+      const pi = shuffleArr[si]
+      if (!palive[pi]) continue
+      if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
+
+      anyAlive = true
+
+      let newDir = pdir[pi]
+      if (Math.random() > STRAIGHTNESS) {
+        newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
+      }
+
+      const nx = px[pi] + DX[newDir]
+      const ny = py[pi] + DY[newDir]
+
+      if (canPlace(nx, ny)) {
+        occupy(nx, ny)
+        px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
+        const hi = pi * MAX_HISTORY + phistLen[pi]
+        phistX[hi] = nx; phistY[hi] = ny
+        phistLen[pi]++
+        pblocked[pi] = 0
+      } else {
+        pblocked[pi]++
+        if (pblocked[pi] >= 2) {
+          palive[pi] = 0
+          if (phistLen[pi] > 4 && Math.random() < 0.5) {
+            const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+            seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
+          }
+        } else {
+          const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+          const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
+          if (canPlace(tx, ty)) {
+            occupy(tx, ty)
+            px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
+            const hi = pi * MAX_HISTORY + phistLen[pi]
+            phistX[hi] = tx; phistY[hi] = ty
+            phistLen[pi]++
+          } else {
+            palive[pi] = 0
+          }
+        }
+      }
+    }
+
+    if (!anyAlive) break
+  }
+
+  // ── Convert to render data ──
+
+  const tempTraces: { pts: number[]; w: number }[] = []
+  const tempPads: { x: number; y: number; r: number }[] = []
+
+  for (let pi = 0; pi < pathCount; pi++) {
+    const len = phistLen[pi]
+    if (len < 3) continue
+    const base = pi * MAX_HISTORY
+
+    const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
+
+    for (let i = 1; i < len - 1; i++) {
+      const dx1 = phistX[base + i] - phistX[base + i - 1]
+      const dy1 = phistY[base + i] - phistY[base + i - 1]
+      const dx2 = phistX[base + i + 1] - phistX[base + i]
+      const dy2 = phistY[base + i + 1] - phistY[base + i]
+      if (dx1 !== dx2 || dy1 !== dy2) {
+        simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
+      }
+    }
+    simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
+
+    if (simplified.length >= 4) {
+      tempTraces.push({ pts: simplified, w: pwidth[pi] })
+      tempPads.push({
+        x: simplified[simplified.length - 2],
+        y: simplified[simplified.length - 1],
+        r: 1.5 + Math.random() * 2,
+      })
+      if (Math.random() < 0.3) {
+        tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+      }
+    }
+  }
+
+  // Pack traces
+  const tc = tempTraces.length
+  let totalPts = 0
+  for (const t of tempTraces) totalPts += t.pts.length
+
+  const tm = new Float32Array(tc * 3)
+  const tp = new Float32Array(totalPts)
+  let ptOffset = 0
+  for (let i = 0; i < tc; i++) {
+    const t = tempTraces[i]
+    tm[i * 3] = ptOffset
+    tm[i * 3 + 1] = t.pts.length / 2
+    tm[i * 3 + 2] = t.w
+    for (let j = 0; j < t.pts.length; j++) tp[ptOffset++] = t.pts[j]
+  }
+
+  // Pack pads
+  const pc = tempPads.length
+  const px2 = new Float32Array(pc)
+  const py2 = new Float32Array(pc)
+  const pr = new Float32Array(pc)
+  for (let i = 0; i < pc; i++) {
+    px2[i] = tempPads[i].x; py2[i] = tempPads[i].y; pr[i] = tempPads[i].r
+  }
+
+  // Pack glows
+  const gc = Math.min(Math.floor(tc / 8), 20)
+  const gx = new Float32Array(gc)
+  const gy = new Float32Array(gc)
+  const gr = new Float32Array(gc)
+  const gph = new Float32Array(gc)
+  const gsp = new Float32Array(gc)
+  for (let i = 0; i < gc; i++) {
+    const ti = Math.floor(Math.random() * tc)
+    const startIdx = tm[ti * 3]
+    const ptC = tm[ti * 3 + 1]
+    const pi2 = Math.floor(Math.random() * ptC)
+    gx[i] = tp[startIdx + pi2 * 2]
+    gy[i] = tp[startIdx + pi2 * 2 + 1]
+    gr[i] = 3 + Math.random() * 5
+    gph[i] = Math.random() * Math.PI * 2
+    gsp[i] = 0.2 + Math.random() * 0.5
+  }
+
+  // Pack pulses
+  const pulses: PulseData[] = []
+  if (!rm && tc > 0) {
+    const numPulses = Math.min(Math.floor(tc / 4), 24)
+    for (let i = 0; i < numPulses; i++) {
+      const ti = Math.floor(Math.random() * tc)
+      const startIdx = tm[ti * 3]
+      const ptC = tm[ti * 3 + 1]
+      if (ptC < 2) continue
+
+      const pts = new Float32Array(ptC * 2)
+      for (let j = 0; j < ptC * 2; j++) pts[j] = tp[startIdx + j]
+
+      const segLens = new Float32Array(ptC - 1)
+      let totalLen = 0
+      for (let j = 0; j < ptC - 1; j++) {
+        const ddx = pts[(j + 1) * 2] - pts[j * 2]
+        const ddy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+        const slen = Math.sqrt(ddx * ddx + ddy * ddy)
+        segLens[j] = slen
+        totalLen += slen
+      }
+
+      if (totalLen < 10) continue
+
+      const speedTier = Math.random()
+      const sp =
+        speedTier < 0.3
+          ? 0.0008 + Math.random() * 0.0007
+          : speedTier < 0.7
+          ? 0.002 + Math.random() * 0.002
+          : 0.005 + Math.random() * 0.004
+
+      pulses.push({
+        pts,
+        segLens,
+        totalLen,
+        pr: Math.random() * (1.0 + sp * 200),
+        sp,
+        ln: 0.04 + Math.random() * 0.06,
+        w: tm[ti * 3 + 2],
+      })
+    }
+  }
+
+  // Write to module state
+  traceMeta = tm; tracePts = tp; traceCount = tc
+  padX = px2; padY = py2; padR = pr; padCount = pc
+  glowX = gx; glowY = gy; glowR = gr; glowPh = gph; glowSp = gsp; glowCount = gc
+  pulseData = pulses
+  ready = true
+}
+
+// ── Draw ───────────────────────────────────────────────────────────────────
+
+function draw(time: number) {
+  ctx.clearRect(0, 0, w, h)
+  if (!ready) return
+
+  // Traces
+  ctx.strokeStyle = traceColor
+  ctx.lineCap = "round"
+  ctx.lineJoin = "round"
+
+  for (let i = 0; i < traceCount; i++) {
+    const startIdx = traceMeta[i * 3]
+    const ptCount = traceMeta[i * 3 + 1]
+    const tw = traceMeta[i * 3 + 2]
+    ctx.lineWidth = tw
+    ctx.beginPath()
+    ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
+    for (let j = 1; j < ptCount; j++) {
+      ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
+    }
+    ctx.stroke()
+  }
+
+  // Pads
+  ctx.fillStyle = padColor
+  for (let i = 0; i < padCount; i++) {
+    ctx.beginPath()
+    ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832)
+    ctx.fill()
+  }
+
+  // Glows
+  const t = time * 0.001
+  const r = cachedR, g = cachedG, b = cachedB
+  const glowMult = isLightMode ? 1.0 : 0.8
+  for (let i = 0; i < glowCount; i++) {
+    const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
+    const radius = glowR[i] * 5
+    const gradR = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
+    gradR.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse * glowMult).toFixed(3)})`)
+    gradR.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse * glowMult).toFixed(3)})`)
+    gradR.addColorStop(1, `rgba(${r},${g},${b},0)`)
+    ctx.fillStyle = gradR
+    ctx.beginPath()
+    ctx.arc(glowX[i], glowY[i], radius, 0, 6.2832)
+    ctx.fill()
+    ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse * glowMult).toFixed(3)})`
+    ctx.beginPath()
+    ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832)
+    ctx.fill()
+  }
+
+  // Pulses
+  if (!reducedMotion) {
+    for (const pl of pulseData) {
+      const life =
+        pl.pr < pl.ln
+          ? pl.pr / pl.ln
+          : pl.pr > 1.0
+          ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
+          : 1.0
+
+      pl.pr += pl.sp
+      if (life <= 0) { pl.pr = 0; continue }
+
+      const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+      const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+      if (hd - td < 1) continue
+
+      function ptAt(d: number): [number, number] {
+        let a = 0
+        for (let i = 0; i < pl.segLens.length; i++) {
+          if (a + pl.segLens[i] >= d) {
+            const f = (d - a) / pl.segLens[i]
+            const i2 = i * 2
+            return [
+              pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f,
+              pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f,
+            ]
+          }
+          a += pl.segLens[i]
+        }
+        const last = pl.segLens.length * 2
+        return [pl.pts[last], pl.pts[last + 1]]
+      }
+
+      const pulseMult = (isLightMode ? 0.8 : 0.7) * life
+      ctx.lineCap = "round"
+      for (let s = 0; s < 8; s++) {
+        const f = s / 8
+        const [x1, y1] = ptAt(td + (hd - td) * f)
+        const [x2, y2] = ptAt(td + (hd - td) * ((s + 1) / 8))
+        ctx.beginPath()
+        ctx.moveTo(x1, y1)
+        ctx.lineTo(x2, y2)
+        ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
+        ctx.lineWidth = pl.w + 2
+        ctx.stroke()
+      }
+
+      const [hx, hy] = ptAt(hd)
+      const headAlpha = 0.5 * life
+      const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+      headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
+      headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
+      headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
+      ctx.fillStyle = headGrad
+      ctx.beginPath()
+      ctx.arc(hx, hy, 8, 0, 6.2832)
+      ctx.fill()
+    }
+  }
+
+  // Content readability vignette
+  const isMobile = w < 768
+  const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
+  const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
+  ctx.globalCompositeOperation = "destination-out"
+  const bandFade = ctx.createLinearGradient(0, 0, w, 0)
+  if (isLightMode && isMobile) {
+    bandFade.addColorStop(0, `rgba(0,0,0,${fadeEdge})`)
+    bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+    bandFade.addColorStop(1, `rgba(0,0,0,${fadeEdge})`)
+  } else {
+    bandFade.addColorStop(0, "rgba(0,0,0,0)")
+    bandFade.addColorStop(0.1, "rgba(0,0,0,0)")
+    bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`)
+    bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+    bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`)
+    bandFade.addColorStop(0.9, "rgba(0,0,0,0)")
+    bandFade.addColorStop(1, "rgba(0,0,0,0)")
+  }
+  ctx.fillStyle = bandFade
+  ctx.fillRect(0, 0, w, h)
+  ctx.globalCompositeOperation = "source-over"
+}
+
+// ── Animation loop ─────────────────────────────────────────────────────────
+
+function startLoop() {
+  if (animTimer !== null) clearInterval(animTimer)
+  if (reducedMotion) {
+    draw(performance.now())
+    return
+  }
+  animTimer = setInterval(() => draw(performance.now()), 33)
+}
+
+function stopLoop() {
+  if (animTimer !== null) {
+    clearInterval(animTimer)
+    animTimer = null
+  }
+}
+
+// ── Message handling ───────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(self as any).onmessage = (
+  e: MessageEvent<
+    | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
+    | { type: "resize"; w: number; h: number; dpr: number; density: number }
+    | { type: "theme"; theme: Theme; accent: string }
+  >
+) => {
+  const msg = e.data
+
+  if (msg.type === "init") {
+    offscreen = msg.canvas
+    ctx = offscreen.getContext("2d")!
+    w = msg.w; h = msg.h; dpr = msg.dpr
+    reducedMotion = msg.reducedMotion
+    offscreen.width = w * dpr
+    offscreen.height = h * dpr
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    applyAccent(msg.accent, msg.theme)
+    generate(w, h, reducedMotion, msg.density)
+    startLoop()
+    return
+  }
+
+  if (msg.type === "resize") {
+    stopLoop()
+    ready = false
+    w = msg.w; h = msg.h; dpr = msg.dpr
+    offscreen.width = w * dpr
+    offscreen.height = h * dpr
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    generate(w, h, reducedMotion, msg.density)
+    startLoop()
+    return
+  }
+
+  if (msg.type === "theme") {
+    applyAccent(msg.accent, msg.theme)
+    if (reducedMotion && ready) draw(performance.now())
+    return
+  }
+}

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -5,6 +5,11 @@
  * main thread. The main thread transfers the canvas once and only sends
  * lightweight resize/theme messages thereafter.
  *
+ * The OffscreenCanvas is 2× viewport height. The circuit is generated for
+ * one viewport tile and drawn twice (at y=0 and y=h) to fill both halves.
+ * A CSS scroll-driven animation on the canvas element handles parallax —
+ * compositor-driven, zero JS lag.
+ *
  * Protocol (main → worker):
  *   { type: 'init',   canvas: OffscreenCanvas, w, h, dpr, reducedMotion, theme, accent, density }
  *   { type: 'resize', w, h, dpr, density }
@@ -23,6 +28,13 @@ interface PulseData {
   sp: number
   ln: number
   w: number
+}
+
+interface DrawablePulse {
+  pl: PulseData
+  life: number
+  hd: number
+  td: number
 }
 
 type Theme = "dark" | "light"
@@ -52,11 +64,9 @@ let pulseData: PulseData[] = []
 
 let w = 0
 let h = 0
-let pageH = 0
 let dpr = 1
 let reducedMotion = false
 let ready = false
-let scrollY = 0
 
 // Color cache
 let cachedR = 100
@@ -323,7 +333,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
     gsp[i] = 0.2 + Math.random() * 0.5
   }
 
-  // Pack pulses
+  // Pack pulses (desktop only)
   const pulses: PulseData[] = []
   if (!rm && gw >= 768 && tc > 0) {
     const numPulses = Math.min(Math.floor(tc / 4), 24)
@@ -376,20 +386,60 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   ready = true
 }
 
+// ── Pulse helpers ───────────────────────────────────────────────────────────
+
+function ptAt(pl: PulseData, d: number): [number, number] {
+  let a = 0
+  for (let i = 0; i < pl.segLens.length; i++) {
+    if (a + pl.segLens[i] >= d) {
+      const f = (d - a) / pl.segLens[i]
+      const i2 = i * 2
+      return [
+        pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f,
+        pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f,
+      ]
+    }
+    a += pl.segLens[i]
+  }
+  const last = pl.segLens.length * 2
+  return [pl.pts[last], pl.pts[last + 1]]
+}
+
+// Advance pulse positions once per frame and return drawable states.
+// Separating update from draw allows drawScene to be called twice per frame
+// (once per tile) without double-advancing the animation.
+function computePulseStates(): DrawablePulse[] {
+  if (reducedMotion || w < 768) return []
+  const result: DrawablePulse[] = []
+  for (const pl of pulseData) {
+    const life =
+      pl.pr < pl.ln
+        ? pl.pr / pl.ln
+        : pl.pr > 1.0
+        ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
+        : 1.0
+    pl.pr += pl.sp
+    if (life <= 0) { pl.pr = 0; continue }
+    const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+    const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+    if (hd - td < 1) continue
+    result.push({ pl, life, hd, td })
+  }
+  return result
+}
+
 // ── Draw ───────────────────────────────────────────────────────────────────
 
-function draw(time: number) {
-  ctx.clearRect(0, 0, w, h)
-  if (!ready) return
-
-  ctx.save()
-  ctx.translate(0, -scrollY)
+// Draws one viewport-sized tile at the current transform origin.
+// Called twice per frame: once for the tile at y=0, once translated to y=h.
+function drawScene(time: number, drawablePulses: DrawablePulse[]) {
+  const t = time * 0.001
+  const r = cachedR, g = cachedG, b = cachedB
 
   // Traces
   ctx.strokeStyle = traceColor
   ctx.lineCap = "round"
   ctx.lineJoin = "round"
-
   for (let i = 0; i < traceCount; i++) {
     const startIdx = traceMeta[i * 3]
     const ptCount = traceMeta[i * 3 + 1]
@@ -412,8 +462,6 @@ function draw(time: number) {
   }
 
   // Glows
-  const t = time * 0.001
-  const r = cachedR, g = cachedG, b = cachedB
   const glowMult = isLightMode ? 1.0 : 0.8
   for (let i = 0; i < glowCount; i++) {
     const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
@@ -432,70 +480,34 @@ function draw(time: number) {
     ctx.fill()
   }
 
-  // Pulses
-  if (!reducedMotion && w >= 768) {
-    for (const pl of pulseData) {
-      const life =
-        pl.pr < pl.ln
-          ? pl.pr / pl.ln
-          : pl.pr > 1.0
-          ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
-          : 1.0
-
-      pl.pr += pl.sp
-      if (life <= 0) { pl.pr = 0; continue }
-
-      const hd = Math.min(pl.pr, 1.0) * pl.totalLen
-      const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
-      if (hd - td < 1) continue
-
-      function ptAt(d: number): [number, number] {
-        let a = 0
-        for (let i = 0; i < pl.segLens.length; i++) {
-          if (a + pl.segLens[i] >= d) {
-            const f = (d - a) / pl.segLens[i]
-            const i2 = i * 2
-            return [
-              pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f,
-              pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f,
-            ]
-          }
-          a += pl.segLens[i]
-        }
-        const last = pl.segLens.length * 2
-        return [pl.pts[last], pl.pts[last + 1]]
-      }
-
-      const pulseMult = (isLightMode ? 0.8 : 0.7) * life
-      ctx.lineCap = "round"
-      for (let s = 0; s < 8; s++) {
-        const f = s / 8
-        const [x1, y1] = ptAt(td + (hd - td) * f)
-        const [x2, y2] = ptAt(td + (hd - td) * ((s + 1) / 8))
-        ctx.beginPath()
-        ctx.moveTo(x1, y1)
-        ctx.lineTo(x2, y2)
-        ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
-        ctx.lineWidth = pl.w + 2
-        ctx.stroke()
-      }
-
-      const [hx, hy] = ptAt(hd)
-      const headAlpha = 0.5 * life
-      const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
-      headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
-      headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
-      headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
-      ctx.fillStyle = headGrad
+  // Pulses (desktop only, pre-computed states — no position advancement here)
+  for (const { pl, life, hd, td } of drawablePulses) {
+    const pulseMult = (isLightMode ? 0.8 : 0.7) * life
+    ctx.lineCap = "round"
+    for (let s = 0; s < 8; s++) {
+      const f = s / 8
+      const [x1, y1] = ptAt(pl, td + (hd - td) * f)
+      const [x2, y2] = ptAt(pl, td + (hd - td) * ((s + 1) / 8))
       ctx.beginPath()
-      ctx.arc(hx, hy, 8, 0, 6.2832)
-      ctx.fill()
+      ctx.moveTo(x1, y1)
+      ctx.lineTo(x2, y2)
+      ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
+      ctx.lineWidth = pl.w + 2
+      ctx.stroke()
     }
+    const [hx, hy] = ptAt(pl, hd)
+    const headAlpha = 0.5 * life
+    const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+    headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
+    headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
+    headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
+    ctx.fillStyle = headGrad
+    ctx.beginPath()
+    ctx.arc(hx, hy, 8, 0, 6.2832)
+    ctx.fill()
   }
 
-  ctx.restore()
-
-  // Content readability vignette
+  // Content readability vignette (per-tile)
   const isMobile = w < 768
   const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
   const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
@@ -517,6 +529,23 @@ function draw(time: number) {
   ctx.fillStyle = bandFade
   ctx.fillRect(0, 0, w, h)
   ctx.globalCompositeOperation = "source-over"
+}
+
+function draw(time: number) {
+  ctx.clearRect(0, 0, w, h * 2)
+  if (!ready) return
+
+  // Advance pulse positions once per frame, collect drawable states
+  const drawablePulses = computePulseStates()
+
+  // Tile 1 (y = 0 .. h)
+  drawScene(time, drawablePulses)
+
+  // Tile 2 (y = h .. 2h) — identical circuit, seamlessly repeating
+  ctx.save()
+  ctx.translate(0, h)
+  drawScene(time, drawablePulses)
+  ctx.restore()
 }
 
 // ── Animation loop ─────────────────────────────────────────────────────────
@@ -542,10 +571,9 @@ function stopLoop() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(self as any).onmessage = (
   e: MessageEvent<
-    | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; pageH: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
-    | { type: "resize"; w: number; h: number; pageH: number; dpr: number; density: number }
+    | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
+    | { type: "resize"; w: number; h: number; dpr: number; density: number }
     | { type: "theme"; theme: Theme; accent: string }
-    | { type: "scroll"; scrollY: number }
   >
 ) => {
   const msg = e.data
@@ -553,13 +581,13 @@ function stopLoop() {
   if (msg.type === "init") {
     offscreen = msg.canvas
     ctx = offscreen.getContext("2d")!
-    w = msg.w; h = msg.h; pageH = msg.pageH; dpr = msg.dpr
+    w = msg.w; h = msg.h; dpr = msg.dpr
     reducedMotion = msg.reducedMotion
     offscreen.width = w * dpr
-    offscreen.height = h * dpr
+    offscreen.height = h * 2 * dpr  // 2× viewport height for tiling
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     applyAccent(msg.accent, msg.theme)
-    generate(w, pageH, reducedMotion, msg.density)
+    generate(w, h, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -567,11 +595,11 @@ function stopLoop() {
   if (msg.type === "resize") {
     stopLoop()
     ready = false
-    w = msg.w; h = msg.h; pageH = msg.pageH; dpr = msg.dpr
+    w = msg.w; h = msg.h; dpr = msg.dpr
     offscreen.width = w * dpr
-    offscreen.height = h * dpr
+    offscreen.height = h * 2 * dpr  // 2× viewport height for tiling
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    generate(w, pageH, reducedMotion, msg.density)
+    generate(w, h, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -580,9 +608,5 @@ function stopLoop() {
     applyAccent(msg.accent, msg.theme)
     if (reducedMotion && ready) draw(performance.now())
     return
-  }
-
-  if (msg.type === "scroll") {
-    scrollY = msg.scrollY
   }
 }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -6,9 +6,9 @@
  * lightweight resize/theme messages thereafter.
  *
  * The OffscreenCanvas is 2× viewport height. The circuit is generated for
- * one viewport tile and drawn twice (at y=0 and y=h) to fill both halves.
- * A CSS scroll-driven animation on the canvas element handles parallax —
- * compositor-driven, zero JS lag.
+ * 1.5× the viewport height (stored in genH). The CSS translateY(-20%) animation
+ * reveals at most y=0..1.4h of canvas, so a soft fade from y=0.85h→1.4h
+ * dissolves the circuit before the content edge — no seam, no empty stripe.
  *
  * Protocol (main → worker):
  *   { type: 'init',   canvas: OffscreenCanvas, w, h, dpr, reducedMotion, theme, accent, density }
@@ -64,6 +64,7 @@ let pulseData: PulseData[] = []
 
 let w = 0
 let h = 0
+let genH = 0     // circuit generation height = Math.round(h * 1.5)
 let dpr = 1
 let reducedMotion = false
 let ready = false
@@ -527,7 +528,7 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
     bandFade.addColorStop(1, "rgba(0,0,0,0)")
   }
   ctx.fillStyle = bandFade
-  ctx.fillRect(0, 0, w, h)
+  ctx.fillRect(0, 0, w, genH)
   ctx.globalCompositeOperation = "source-over"
 }
 
@@ -535,32 +536,19 @@ function draw(time: number) {
   ctx.clearRect(0, 0, w, h * 2)
   if (!ready) return
 
-  // Advance pulse positions once per frame, collect drawable states
   const drawablePulses = computePulseStates()
-
-  // Tile 1 (y = 0 .. h)
   drawScene(time, drawablePulses)
 
-  // Tile 2 (y = h .. 2h) — identical circuit, seamlessly repeating
-  ctx.save()
-  ctx.translate(0, h)
-  drawScene(time, drawablePulses)
-  ctx.restore()
-
-  // Cross-fade at the tile seam (y = h) to hide the hard edge.
-  // Fades tile 1 out before the seam and tile 2 in after it.
-  const fadePx = h * 0.18
+  // Soft bottom fade — circuit dissolves well before the canvas edge,
+  // so the scroll range (max visible: y=0..1.4h) never shows a hard cutoff.
+  const fadeStart = h * 0.85
+  const fadeEnd = h * 1.4
   ctx.globalCompositeOperation = "destination-out"
-  const btmFade = ctx.createLinearGradient(0, h - fadePx, 0, h)
+  const btmFade = ctx.createLinearGradient(0, fadeStart, 0, fadeEnd)
   btmFade.addColorStop(0, "rgba(0,0,0,0)")
   btmFade.addColorStop(1, "rgba(0,0,0,1)")
   ctx.fillStyle = btmFade
-  ctx.fillRect(0, h - fadePx, w, fadePx)
-  const topFade = ctx.createLinearGradient(0, h, 0, h + fadePx)
-  topFade.addColorStop(0, "rgba(0,0,0,1)")
-  topFade.addColorStop(1, "rgba(0,0,0,0)")
-  ctx.fillStyle = topFade
-  ctx.fillRect(0, h, w, fadePx)
+  ctx.fillRect(0, fadeStart, w, fadeEnd - fadeStart)
   ctx.globalCompositeOperation = "source-over"
 }
 
@@ -598,12 +586,13 @@ function stopLoop() {
     offscreen = msg.canvas
     ctx = offscreen.getContext("2d")!
     w = msg.w; h = msg.h; dpr = msg.dpr
+    genH = Math.round(h * 1.5)
     reducedMotion = msg.reducedMotion
     offscreen.width = w * dpr
-    offscreen.height = h * 2 * dpr  // 2× viewport height for tiling
+    offscreen.height = h * 2 * dpr  // 2× viewport height for CSS animation
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     applyAccent(msg.accent, msg.theme)
-    generate(w, h, reducedMotion, msg.density)
+    generate(w, genH, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -612,10 +601,11 @@ function stopLoop() {
     stopLoop()
     ready = false
     w = msg.w; h = msg.h; dpr = msg.dpr
+    genH = Math.round(h * 1.5)
     offscreen.width = w * dpr
-    offscreen.height = h * 2 * dpr  // 2× viewport height for tiling
+    offscreen.height = h * 2 * dpr  // 2× viewport height for CSS animation
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    generate(w, h, reducedMotion, msg.density)
+    generate(w, genH, reducedMotion, msg.density)
     startLoop()
     return
   }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -6,9 +6,9 @@
  * lightweight resize/theme messages thereafter.
  *
  * The OffscreenCanvas is 2× viewport height. The circuit is generated for
- * 1.5× the viewport height (stored in genH). The CSS translateY(-20%) animation
- * reveals at most y=0..1.4h of canvas, so a soft fade from y=0.85h→1.4h
- * dissolves the circuit before the content edge — no seam, no empty stripe.
+ * one viewport tile and drawn twice per frame (tile 1 at y=0, tile 2 at y=h).
+ * Seam stubs — short mirrored vertical traces at the top and bottom edges —
+ * connect geometrically when the tile repeats, hiding the seam.
  *
  * Protocol (main → worker):
  *   { type: 'init',   canvas: OffscreenCanvas, w, h, dpr, reducedMotion, theme, accent, density }
@@ -64,7 +64,6 @@ let pulseData: PulseData[] = []
 
 let w = 0
 let h = 0
-let genH = 0     // circuit generation height = Math.round(h * 1.5)
 let dpr = 1
 let reducedMotion = false
 let ready = false
@@ -154,18 +153,55 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
     }
   }
 
+  // ── Seaming stubs (seamless vertical tiling) ──
+  //
+  // Short deterministic vertical traces at evenly-spaced x positions.
+  // Top stubs (y=0 → seamRows) and bottom stubs (y=rows-1 → rows-1-seamRows)
+  // use identical x positions and widths. When the tile stacks, the bottom
+  // stub of tile N and the top stub of tile N+1 meet at the seam and form a
+  // continuous trace — no cross-fade or empty stripe needed.
+  // All other generation branches out independently from the stub endpoints.
+
+  const seamRows = Math.max(3, Math.ceil(rows * 0.05))
+  const seamStep = 8  // one stub pair every 8 grid columns (~80 px)
+
+  for (let sx = 4; sx < cols - 4; sx += seamStep) {
+    const sw = 0.5 + ((sx * 3 + 7) % 15) / 30  // deterministic width 0.5..1.0
+
+    // Top stub: (sx, 0) → (sx, seamRows), straight south
+    if (pathCount < MAX_PATHS) {
+      const pi = pathCount++
+      for (let s = 0; s <= seamRows; s++) {
+        phistX[pi * MAX_HISTORY + s] = sx
+        phistY[pi * MAX_HISTORY + s] = s
+        if (inBounds(sx, s)) grid[at(sx, s)] = 1
+      }
+      phistLen[pi] = seamRows + 1
+      pwidth[pi] = sw
+      palive[pi] = 0
+      seedPath(sx, seamRows + 1, 1, 15 + (sx % 5) * 5, sw * 0.9)
+    }
+
+    // Bottom stub: mirror of top — (sx, rows-1) → (sx, rows-1-seamRows), straight north
+    if (pathCount < MAX_PATHS) {
+      const pi = pathCount++
+      for (let s = 0; s <= seamRows; s++) {
+        phistX[pi * MAX_HISTORY + s] = sx
+        phistY[pi * MAX_HISTORY + s] = rows - 1 - s
+        if (inBounds(sx, rows - 1 - s)) grid[at(sx, rows - 1 - s)] = 1
+      }
+      phistLen[pi] = seamRows + 1
+      pwidth[pi] = sw
+      palive[pi] = 0
+      seedPath(sx, rows - 2 - seamRows, 3, 15 + (sx % 5) * 5, sw * 0.9)
+    }
+  }
+
   // ── Seeding ──
 
-  // Edge bundles (not density-scaled — keep edges full at all viewport sizes)
-  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
-  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  // Left/right edge bundles (non-tiling edges — random seeding is fine here)
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
-
-  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
-    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-  }
   for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
     seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
     seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
@@ -528,7 +564,7 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
     bandFade.addColorStop(1, "rgba(0,0,0,0)")
   }
   ctx.fillStyle = bandFade
-  ctx.fillRect(0, 0, w, genH)
+  ctx.fillRect(0, 0, w, h)
   ctx.globalCompositeOperation = "source-over"
 }
 
@@ -537,19 +573,15 @@ function draw(time: number) {
   if (!ready) return
 
   const drawablePulses = computePulseStates()
+
+  // Tile 1 at y=0
   drawScene(time, drawablePulses)
 
-  // Soft bottom fade — circuit dissolves well before the canvas edge,
-  // so the scroll range (max visible: y=0..1.4h) never shows a hard cutoff.
-  const fadeStart = h * 0.85
-  const fadeEnd = h * 1.4
-  ctx.globalCompositeOperation = "destination-out"
-  const btmFade = ctx.createLinearGradient(0, fadeStart, 0, fadeEnd)
-  btmFade.addColorStop(0, "rgba(0,0,0,0)")
-  btmFade.addColorStop(1, "rgba(0,0,0,1)")
-  ctx.fillStyle = btmFade
-  ctx.fillRect(0, fadeStart, w, fadeEnd - fadeStart)
-  ctx.globalCompositeOperation = "source-over"
+  // Tile 2 at y=h — same frame state, no double-advancing
+  ctx.save()
+  ctx.translate(0, h)
+  drawScene(time, drawablePulses)
+  ctx.restore()
 }
 
 // ── Animation loop ─────────────────────────────────────────────────────────
@@ -586,13 +618,12 @@ function stopLoop() {
     offscreen = msg.canvas
     ctx = offscreen.getContext("2d")!
     w = msg.w; h = msg.h; dpr = msg.dpr
-    genH = Math.round(h * 1.5)
     reducedMotion = msg.reducedMotion
     offscreen.width = w * dpr
     offscreen.height = h * 2 * dpr  // 2× viewport height for CSS animation
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     applyAccent(msg.accent, msg.theme)
-    generate(w, genH, reducedMotion, msg.density)
+    generate(w, h, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -601,11 +632,10 @@ function stopLoop() {
     stopLoop()
     ready = false
     w = msg.w; h = msg.h; dpr = msg.dpr
-    genH = Math.round(h * 1.5)
     offscreen.width = w * dpr
     offscreen.height = h * 2 * dpr  // 2× viewport height for CSS animation
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    generate(w, genH, reducedMotion, msg.density)
+    generate(w, h, reducedMotion, msg.density)
     startLoop()
     return
   }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -52,9 +52,11 @@ let pulseData: PulseData[] = []
 
 let w = 0
 let h = 0
+let pageH = 0
 let dpr = 1
 let reducedMotion = false
 let ready = false
+let scrollY = 0
 
 // Color cache
 let cachedR = 100
@@ -323,7 +325,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
 
   // Pack pulses
   const pulses: PulseData[] = []
-  if (!rm && tc > 0) {
+  if (!rm && gw >= 768 && tc > 0) {
     const numPulses = Math.min(Math.floor(tc / 4), 24)
     for (let i = 0; i < numPulses; i++) {
       const ti = Math.floor(Math.random() * tc)
@@ -380,6 +382,9 @@ function draw(time: number) {
   ctx.clearRect(0, 0, w, h)
   if (!ready) return
 
+  ctx.save()
+  ctx.translate(0, -scrollY)
+
   // Traces
   ctx.strokeStyle = traceColor
   ctx.lineCap = "round"
@@ -428,7 +433,7 @@ function draw(time: number) {
   }
 
   // Pulses
-  if (!reducedMotion) {
+  if (!reducedMotion && w >= 768) {
     for (const pl of pulseData) {
       const life =
         pl.pr < pl.ln
@@ -488,6 +493,8 @@ function draw(time: number) {
     }
   }
 
+  ctx.restore()
+
   // Content readability vignette
   const isMobile = w < 768
   const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
@@ -535,9 +542,10 @@ function stopLoop() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(self as any).onmessage = (
   e: MessageEvent<
-    | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
-    | { type: "resize"; w: number; h: number; dpr: number; density: number }
+    | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; pageH: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
+    | { type: "resize"; w: number; h: number; pageH: number; dpr: number; density: number }
     | { type: "theme"; theme: Theme; accent: string }
+    | { type: "scroll"; scrollY: number }
   >
 ) => {
   const msg = e.data
@@ -545,13 +553,13 @@ function stopLoop() {
   if (msg.type === "init") {
     offscreen = msg.canvas
     ctx = offscreen.getContext("2d")!
-    w = msg.w; h = msg.h; dpr = msg.dpr
+    w = msg.w; h = msg.h; pageH = msg.pageH; dpr = msg.dpr
     reducedMotion = msg.reducedMotion
     offscreen.width = w * dpr
     offscreen.height = h * dpr
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     applyAccent(msg.accent, msg.theme)
-    generate(w, h, reducedMotion, msg.density)
+    generate(w, pageH, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -559,11 +567,11 @@ function stopLoop() {
   if (msg.type === "resize") {
     stopLoop()
     ready = false
-    w = msg.w; h = msg.h; dpr = msg.dpr
+    w = msg.w; h = msg.h; pageH = msg.pageH; dpr = msg.dpr
     offscreen.width = w * dpr
     offscreen.height = h * dpr
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-    generate(w, h, reducedMotion, msg.density)
+    generate(w, pageH, reducedMotion, msg.density)
     startLoop()
     return
   }
@@ -572,5 +580,9 @@ function stopLoop() {
     applyAccent(msg.accent, msg.theme)
     if (reducedMotion && ready) draw(performance.now())
     return
+  }
+
+  if (msg.type === "scroll") {
+    scrollY = msg.scrollY
   }
 }


### PR DESCRIPTION
## Summary

- Combines the old generation worker and main-thread render loop into a single `workers/circuit-worker.ts` that owns an `OffscreenCanvas` — generation, drawing, and the animation loop all run off the main thread
- `components/circuit-bg.tsx` is reduced to ~70 lines: transfer the canvas once on mount, then relay `resize` and `theme` messages to the worker
- Adds mobile density reduction: viewports under 768px get 40% interior seed density (edge seeding unchanged), keeping the animation light on slower devices

## How it works

The main thread calls `canvas.transferControlToOffscreen()` and posts the handle to the worker as a transferable. The worker gets a 2D context directly from the OffscreenCanvas and drives a `setInterval(draw, 33)` loop (`requestAnimationFrame` is not available in dedicated workers). Resize and theme changes are sent as lightweight messages; color values are read from the DOM on the main thread and forwarded so the worker never needs `getComputedStyle`.

Graceful degradation: if `transferControlToOffscreen` is not supported (old Safari <17), the canvas stays blank rather than crashing.

## Test plan

- [x] Circuit animates continuously in dark mode
- [x] Circuit animates continuously in light mode (accent color updates on theme toggle)
- [x] Resize window — circuit regenerates after 300ms debounce
- [x] Resize below 768px — density visibly lower (fewer interior traces)
- [x] DevTools Performance tab: no long tasks on main thread during animation
- [x] `prefers-reduced-motion` enabled: circuit renders static (no pulses, no loop)
- [x] Page loads and functions normally if `transferControlToOffscreen` is stubbed out