### PR TITLE
Add circuit background with reduced density on mobile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/components/sidebar"
 import { ChatPanelLazy } from "@/components/chat-panel-lazy"
 import { CursorGlow } from "@/components/cursor-glow"
 import { Analytics } from "@vercel/analytics/react"
+import { CircuitBgLazy } from "@/components/circuit-bg-lazy"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
 import { getPosts } from "@/lib/content"
 import { headers } from "next/headers"
@@ -130,8 +131,9 @@ export default async function RootLayout({
             <>
               <CursorGlow />
               <Sidebar />
-              <div className="pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
-                <div className="mx-auto max-w-[900px] px-6 md:px-12">
+              <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+                <CircuitBgLazy />
+                <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
                   {children}
                 </div>
               </div>

--- a/components/circuit-bg-lazy.tsx
+++ b/components/circuit-bg-lazy.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const CircuitBg = dynamic(
+  () => import("./circuit-bg").then((mod) => mod.CircuitBg),
+  { ssr: false },
+)
+
+export function CircuitBgLazy() {
+  return <CircuitBg />
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -88,8 +88,8 @@ export function CircuitBg() {
     let genId = 0
 
     function requestGenerate() {
-      w = canvas.clientWidth || window.innerWidth
-      h = canvas.clientHeight || window.innerHeight
+      w = window.innerWidth
+      h = window.innerHeight
       canvas.width = w * dpr; canvas.height = h * dpr
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
       genId++
@@ -285,7 +285,7 @@ export function CircuitBg() {
     <canvas
       ref={canvasRef}
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 h-full w-full print:hidden"
+      className="pointer-events-none fixed inset-0 -z-10 print:hidden"
     />
   )
 }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -1,0 +1,289 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/**
+ * PCB circuit board background.
+ *
+ * Generation runs in a Web Worker (zero main-thread blocking).
+ * Rendering: batched canvas draws, cached colors, pre-computed pulse geometry.
+ * Mobile: density reduced to 40% of desktop to keep things light on smaller devices.
+ */
+export function CircuitBg() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current!
+    const ctx = canvas.getContext("2d")!
+    if (!ctx) return
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
+
+    // ── Render data (received from worker) ──
+
+    let traceMeta = new Float32Array(0)
+    let tracePts = new Float32Array(0)
+    let traceCount = 0
+
+    let padX = new Float32Array(0)
+    let padY = new Float32Array(0)
+    let padR = new Float32Array(0)
+    let padCount = 0
+
+    let glowX = new Float32Array(0)
+    let glowY = new Float32Array(0)
+    let glowR = new Float32Array(0)
+    let glowPh = new Float32Array(0)
+    let glowSp = new Float32Array(0)
+    let glowCount = 0
+
+    interface PulseData {
+      pts: Float32Array
+      segLens: Float32Array
+      totalLen: number
+      pr: number
+      sp: number
+      ln: number
+      w: number
+    }
+    let pulseData: PulseData[] = []
+
+    let w = 0, h = 0
+    let ready = false
+
+    // ── Cached color state ──
+
+    let cachedR = 100, cachedG = 255, cachedB = 218
+    let traceColor = ""
+    let padColor = ""
+    let isLightMode = false
+
+    function updateColors() {
+      isLightMode = document.documentElement.getAttribute("data-theme") === "light"
+      const accent = getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#64ffda"
+      const s = accent.startsWith("#") ? accent.slice(1) : ""
+      if (s.length >= 6) {
+        cachedR = parseInt(s.slice(0, 2), 16)
+        cachedG = parseInt(s.slice(2, 4), 16)
+        cachedB = parseInt(s.slice(4, 6), 16)
+      } else if (s.length === 3) {
+        cachedR = parseInt(s[0] + s[0], 16)
+        cachedG = parseInt(s[1] + s[1], 16)
+        cachedB = parseInt(s[2] + s[2], 16)
+      }
+      traceColor = `rgba(${cachedR},${cachedG},${cachedB},${isLightMode ? 0.11 : 0.06})`
+      padColor = `rgba(${cachedR},${cachedG},${cachedB},${isLightMode ? 0.13 : 0.07})`
+    }
+
+    // ── Worker ──
+
+    const worker = new Worker(
+      new URL("../workers/circuit-generate.ts", import.meta.url),
+    )
+
+    let genId = 0
+
+    function requestGenerate() {
+      w = canvas.clientWidth || window.innerWidth
+      h = canvas.clientHeight || window.innerHeight
+      canvas.width = w * dpr; canvas.height = h * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      genId++
+      worker.postMessage({ w, h, reducedMotion, density: getDensity(), id: genId })
+    }
+
+    worker.onmessage = (e) => {
+      const d = e.data
+      if (d.id !== genId) return // stale result from a previous resize
+
+      traceMeta = d.traceMeta; tracePts = d.tracePts; traceCount = d.traceCount
+      padX = d.padX; padY = d.padY; padR = d.padR; padCount = d.padCount
+      glowX = d.glowX; glowY = d.glowY; glowR = d.glowR
+      glowPh = d.glowPh; glowSp = d.glowSp; glowCount = d.glowCount
+      pulseData = d.pulses
+      ready = true
+      updateColors()
+      if (reducedMotion) draw(0)
+    }
+
+    // ── Draw ──
+
+    function draw(time: number) {
+      ctx.clearRect(0, 0, w, h)
+      if (!ready) return
+
+      // Traces
+      ctx.strokeStyle = traceColor
+      ctx.lineCap = "round"
+      ctx.lineJoin = "round"
+
+      for (let i = 0; i < traceCount; i++) {
+        const startIdx = traceMeta[i * 3]
+        const ptCount = traceMeta[i * 3 + 1]
+        const tw = traceMeta[i * 3 + 2]
+        ctx.lineWidth = tw
+        ctx.beginPath()
+        ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
+        for (let j = 1; j < ptCount; j++) {
+          ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
+        }
+        ctx.stroke()
+      }
+
+      // Pads
+      ctx.fillStyle = padColor
+      for (let i = 0; i < padCount; i++) {
+        ctx.beginPath()
+        ctx.arc(padX[i], padY[i], padR[i], 0, 6.2832)
+        ctx.fill()
+      }
+
+      // Glows
+      const t = time * 0.001
+      const r = cachedR, g = cachedG, b = cachedB
+      const glowMult = isLightMode ? 1.0 : 0.8
+      for (let i = 0; i < glowCount; i++) {
+        const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
+        const radius = glowR[i] * 5
+        const gr = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
+        gr.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse * glowMult).toFixed(3)})`)
+        gr.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse * glowMult).toFixed(3)})`)
+        gr.addColorStop(1, `rgba(${r},${g},${b},0)`)
+        ctx.fillStyle = gr
+        ctx.beginPath()
+        ctx.arc(glowX[i], glowY[i], radius, 0, 6.2832)
+        ctx.fill()
+        ctx.fillStyle = `rgba(${r},${g},${b},${(0.4 * pulse * glowMult).toFixed(3)})`
+        ctx.beginPath()
+        ctx.arc(glowX[i], glowY[i], glowR[i] * 0.5, 0, 6.2832)
+        ctx.fill()
+      }
+
+      // Pulses
+      if (!reducedMotion) {
+        for (const pl of pulseData) {
+          const life =
+            pl.pr < pl.ln
+              ? pl.pr / pl.ln
+              : pl.pr > 1.0
+              ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
+              : 1.0
+
+          pl.pr += pl.sp
+          if (life <= 0) { pl.pr = 0; continue }
+
+          const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+          const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+          if (hd - td < 1) continue
+
+          function ptAt(d: number): [number, number] {
+            let a = 0
+            for (let i = 0; i < pl.segLens.length; i++) {
+              if (a + pl.segLens[i] >= d) {
+                const f = (d - a) / pl.segLens[i]
+                const i2 = i * 2
+                return [
+                  pl.pts[i2] + (pl.pts[i2 + 2] - pl.pts[i2]) * f,
+                  pl.pts[i2 + 1] + (pl.pts[i2 + 3] - pl.pts[i2 + 1]) * f,
+                ]
+              }
+              a += pl.segLens[i]
+            }
+            const last = pl.segLens.length * 2
+            return [pl.pts[last], pl.pts[last + 1]]
+          }
+
+          const pulseMult = (isLightMode ? 0.8 : 0.7) * life
+          ctx.lineCap = "round"
+          for (let s = 0; s < 8; s++) {
+            const f = s / 8
+            const [x1, y1] = ptAt(td + (hd - td) * f)
+            const [x2, y2] = ptAt(td + (hd - td) * ((s + 1) / 8))
+            ctx.beginPath()
+            ctx.moveTo(x1, y1)
+            ctx.lineTo(x2, y2)
+            ctx.strokeStyle = `rgba(${r},${g},${b},${(f * f * 0.5 * pulseMult).toFixed(3)})`
+            ctx.lineWidth = pl.w + 2
+            ctx.stroke()
+          }
+
+          const [hx, hy] = ptAt(hd)
+          const headAlpha = 0.5 * life
+          const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+          headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
+          headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
+          headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
+          ctx.fillStyle = headGrad
+          ctx.beginPath()
+          ctx.arc(hx, hy, 8, 0, 6.2832)
+          ctx.fill()
+        }
+      }
+
+      // Content readability vignette
+      const isMobile = w < 768
+      const fadeStrength = isLightMode ? (isMobile ? 0.55 : 0.35) : 0.65
+      const fadeEdge = isLightMode ? (isMobile ? 0.45 : 0.25) : 0.6
+      ctx.globalCompositeOperation = "destination-out"
+      const bandFade = ctx.createLinearGradient(0, 0, w, 0)
+      if (isLightMode && isMobile) {
+        bandFade.addColorStop(0, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+        bandFade.addColorStop(1, `rgba(0,0,0,${fadeEdge})`)
+      } else {
+        bandFade.addColorStop(0, "rgba(0,0,0,0)")
+        bandFade.addColorStop(0.1, "rgba(0,0,0,0)")
+        bandFade.addColorStop(0.18, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.5, `rgba(0,0,0,${fadeStrength})`)
+        bandFade.addColorStop(0.82, `rgba(0,0,0,${fadeEdge})`)
+        bandFade.addColorStop(0.9, "rgba(0,0,0,0)")
+        bandFade.addColorStop(1, "rgba(0,0,0,0)")
+      }
+      ctx.fillStyle = bandFade
+      ctx.fillRect(0, 0, w, h)
+      ctx.globalCompositeOperation = "source-over"
+    }
+
+    // ── Lifecycle ──
+
+    requestGenerate()
+    let rt: ReturnType<typeof setTimeout>
+    const onResize = () => { clearTimeout(rt); rt = setTimeout(requestGenerate, 300) }
+    window.addEventListener("resize", onResize)
+
+    const obs = new MutationObserver(() => {
+      updateColors()
+      if (reducedMotion && ready) draw(0)
+    })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
+
+    if (reducedMotion) {
+      return () => { worker.terminate(); window.removeEventListener("resize", onResize); obs.disconnect() }
+    }
+
+    let fid: number, lt = 0
+    const loop = (t: number) => {
+      if (t - lt >= 33) { draw(t); lt = t }
+      fid = requestAnimationFrame(loop)
+    }
+    fid = requestAnimationFrame(loop)
+
+    return () => {
+      cancelAnimationFrame(fid)
+      clearTimeout(rt)
+      worker.terminate()
+      window.removeEventListener("resize", onResize)
+      obs.disconnect()
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 h-full w-full print:hidden"
+    />
+  )
+}

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -18,8 +18,10 @@ export function CircuitBg() {
     if (!ctx) return
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const isMobile = window.innerWidth < 768
+    const staticOnly = reducedMotion || isMobile // mobile canvas draw is too heavy to animate
     const dpr = Math.min(window.devicePixelRatio || 1, 2)
-    const getDensity = () => (window.innerWidth < 768 ? 0.4 : 1.0)
+    const getDensity = () => (isMobile ? 0.4 : 1.0)
 
     // ── Render data (received from worker) ──
 
@@ -105,7 +107,7 @@ export function CircuitBg() {
       pulseData = d.pulses
       ready = true
       updateColors()
-      if (reducedMotion) draw(0)
+      if (staticOnly) draw(0)
     }
 
     // ── Draw ──
@@ -255,11 +257,11 @@ export function CircuitBg() {
 
     const obs = new MutationObserver(() => {
       updateColors()
-      if (reducedMotion && ready) draw(0)
+      if (staticOnly && ready) draw(0)
     })
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 
-    if (reducedMotion) {
+    if (staticOnly) {
       return () => { worker.terminate(); window.removeEventListener("resize", onResize); obs.disconnect() }
     }
 

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -12,6 +12,8 @@
  * density: 0–1 multiplier applied to interior seed counts (use 0.4 on mobile).
  */
 
+export {}
+
 const DX = [1, 0, -1, 0, 1, -1, -1, 1]
 const DY = [0, 1, 0, -1, 1, 1, -1, -1]
 

--- a/workers/circuit-generate.ts
+++ b/workers/circuit-generate.ts
@@ -1,0 +1,315 @@
+/**
+ * Web Worker for PCB circuit board generation.
+ *
+ * Runs the expensive path growth algorithm off the main thread so it
+ * doesn't block first paint or contribute to Total Blocking Time.
+ *
+ * Receives: { w, h, reducedMotion, density, id }
+ * Returns:  { id, traceCount, traceMeta, tracePts, padCount, padX, padY, padR,
+ *             glowCount, glowX, glowY, glowR, glowPh, glowSp, pulses }
+ *
+ * Large typed arrays are transferred (zero-copy). Pulse data is cloned.
+ * density: 0–1 multiplier applied to interior seed counts (use 0.4 on mobile).
+ */
+
+const DX = [1, 0, -1, 0, 1, -1, -1, 1]
+const DY = [0, 1, 0, -1, 1, 1, -1, -1]
+
+interface PulseResult {
+  pts: Float32Array
+  segLens: Float32Array
+  totalLen: number
+  pr: number
+  sp: number
+  ln: number
+  w: number
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const worker = self as any
+
+worker.onmessage = (e: MessageEvent<{ w: number; h: number; reducedMotion: boolean; density: number; id: number }>) => {
+  const { w, h, reducedMotion, density, id } = e.data
+
+  const gridSize = 10
+  const cols = Math.ceil(w / gridSize)
+  const rows = Math.ceil(h / gridSize)
+  const grid = new Uint8Array(cols * rows)
+
+  const at = (x: number, y: number) => y * cols + x
+  const inBounds = (x: number, y: number) => x >= 0 && x < cols && y >= 0 && y < rows
+  const canPlace = (x: number, y: number) => inBounds(x, y) && grid[at(x, y)] === 0
+
+  function occupy(x: number, y: number) {
+    if (inBounds(x, y)) grid[at(x, y)] = 1
+  }
+
+  // ── Path storage ──
+
+  const MAX_PATHS = 2000
+  const MAX_HISTORY = 100
+  const px = new Int16Array(MAX_PATHS)
+  const py = new Int16Array(MAX_PATHS)
+  const pdir = new Uint8Array(MAX_PATHS)
+  const phistX = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistY = new Int16Array(MAX_PATHS * MAX_HISTORY)
+  const phistLen = new Uint16Array(MAX_PATHS)
+  const pmaxLen = new Uint16Array(MAX_PATHS)
+  const palive = new Uint8Array(MAX_PATHS)
+  const pwidth = new Float32Array(MAX_PATHS)
+  const pblocked = new Uint8Array(MAX_PATHS)
+  let pathCount = 0
+
+  function seedPath(x: number, y: number, dir: number, maxLen: number, width: number) {
+    if (pathCount >= MAX_PATHS || !canPlace(x, y)) return
+    occupy(x, y)
+    const i = pathCount++
+    px[i] = x; py[i] = y; pdir[i] = dir
+    phistX[i * MAX_HISTORY] = x; phistY[i * MAX_HISTORY] = y
+    phistLen[i] = 1; pmaxLen[i] = Math.min(maxLen, MAX_HISTORY)
+    palive[i] = 1; pwidth[i] = width; pblocked[i] = 0
+  }
+
+  function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
+    const bundleSize = 3 + Math.floor(Math.random() * 5)
+    const pathLen = 40 + Math.floor(Math.random() * 50)
+    const bw = 0.6 + Math.random() * 0.5
+    for (let i = 0; i < bundleSize; i++) {
+      seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
+    }
+  }
+
+  // ── Seeding ──
+
+  // Edge seeds — not density-scaled (keep edges lively at all sizes)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, 0, 1, 1, 0)
+  for (let x = 3; x < cols - 10; x += 6 + Math.floor(Math.random() * 6)) seedBundle(x, rows - 1, 3, 1, 0)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
+  for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
+
+  for (let x = 2; x < cols - 2; x += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(x, 0, 1, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(x, rows - 1, 3, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+  for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
+    seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+  }
+
+  // Interior seeds — density-scaled
+  const intBundles = Math.floor((cols * rows) / 800 * density) + 8
+  for (let i = 0; i < intBundles; i++) {
+    const x = 5 + Math.floor(Math.random() * (cols - 10))
+    const y = 5 + Math.floor(Math.random() * (rows - 10))
+    const dir = Math.floor(Math.random() * 4)
+    const perpDx = dir === 1 || dir === 3 ? 1 : 0
+    const perpDy = dir === 0 || dir === 2 ? 1 : 0
+    seedBundle(x, y, dir, perpDx, perpDy)
+  }
+
+  const intSeeds = Math.floor((cols * rows) / 250 * density) + 15
+  for (let i = 0; i < intSeeds; i++) {
+    const x = 3 + Math.floor(Math.random() * (cols - 6))
+    const y = 3 + Math.floor(Math.random() * (rows - 6))
+    seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+  }
+
+  // ── Round-robin growth ──
+
+  const STRAIGHTNESS = 0.93
+  const maxSteps = 80
+  const shuffleArr = new Uint16Array(MAX_PATHS)
+
+  for (let step = 0; step < maxSteps; step++) {
+    const n = pathCount
+    for (let i = 0; i < n; i++) shuffleArr[i] = i
+    for (let i = n - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      const tmp = shuffleArr[i]; shuffleArr[i] = shuffleArr[j]; shuffleArr[j] = tmp
+    }
+
+    let anyAlive = false
+
+    for (let si = 0; si < n; si++) {
+      const pi = shuffleArr[si]
+      if (!palive[pi]) continue
+      if (phistLen[pi] >= pmaxLen[pi]) { palive[pi] = 0; continue }
+
+      anyAlive = true
+
+      let newDir = pdir[pi]
+      if (Math.random() > STRAIGHTNESS) {
+        newDir = (newDir + (Math.random() < 0.5 ? 1 : 3)) % 4
+      }
+
+      const nx = px[pi] + DX[newDir]
+      const ny = py[pi] + DY[newDir]
+
+      if (canPlace(nx, ny)) {
+        occupy(nx, ny)
+        px[pi] = nx; py[pi] = ny; pdir[pi] = newDir
+        const hi = pi * MAX_HISTORY + phistLen[pi]
+        phistX[hi] = nx; phistY[hi] = ny
+        phistLen[pi]++
+        pblocked[pi] = 0
+      } else {
+        pblocked[pi]++
+        if (pblocked[pi] >= 2) {
+          palive[pi] = 0
+          if (phistLen[pi] > 4 && Math.random() < 0.5) {
+            const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+            seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
+          }
+        } else {
+          const tryDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
+          const tx = px[pi] + DX[tryDir], ty = py[pi] + DY[tryDir]
+          if (canPlace(tx, ty)) {
+            occupy(tx, ty)
+            px[pi] = tx; py[pi] = ty; pdir[pi] = tryDir
+            const hi = pi * MAX_HISTORY + phistLen[pi]
+            phistX[hi] = tx; phistY[hi] = ty
+            phistLen[pi]++
+          } else {
+            palive[pi] = 0
+          }
+        }
+      }
+    }
+
+    if (!anyAlive) break
+  }
+
+  // ── Convert to render data ──
+
+  const tempTraces: { pts: number[]; w: number }[] = []
+  const tempPads: { x: number; y: number; r: number }[] = []
+
+  for (let pi = 0; pi < pathCount; pi++) {
+    const len = phistLen[pi]
+    if (len < 3) continue
+    const base = pi * MAX_HISTORY
+
+    const simplified: number[] = [phistX[base] * gridSize, phistY[base] * gridSize]
+
+    for (let i = 1; i < len - 1; i++) {
+      const dx1 = phistX[base + i] - phistX[base + i - 1]
+      const dy1 = phistY[base + i] - phistY[base + i - 1]
+      const dx2 = phistX[base + i + 1] - phistX[base + i]
+      const dy2 = phistY[base + i + 1] - phistY[base + i]
+      if (dx1 !== dx2 || dy1 !== dy2) {
+        simplified.push(phistX[base + i] * gridSize, phistY[base + i] * gridSize)
+      }
+    }
+    simplified.push(phistX[base + len - 1] * gridSize, phistY[base + len - 1] * gridSize)
+
+    if (simplified.length >= 4) {
+      tempTraces.push({ pts: simplified, w: pwidth[pi] })
+      tempPads.push({ x: simplified[simplified.length - 2], y: simplified[simplified.length - 1], r: 1.5 + Math.random() * 2 })
+      if (Math.random() < 0.3) {
+        tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+      }
+    }
+  }
+
+  // Pack traces
+  const traceCount = tempTraces.length
+  let totalPts = 0
+  for (const t of tempTraces) totalPts += t.pts.length
+
+  const traceMeta = new Float32Array(traceCount * 3)
+  const tracePts = new Float32Array(totalPts)
+  let ptOffset = 0
+  for (let i = 0; i < traceCount; i++) {
+    const t = tempTraces[i]
+    traceMeta[i * 3] = ptOffset
+    traceMeta[i * 3 + 1] = t.pts.length / 2
+    traceMeta[i * 3 + 2] = t.w
+    for (let j = 0; j < t.pts.length; j++) tracePts[ptOffset++] = t.pts[j]
+  }
+
+  // Pack pads
+  const padCount = tempPads.length
+  const padX = new Float32Array(padCount)
+  const padY = new Float32Array(padCount)
+  const padR = new Float32Array(padCount)
+  for (let i = 0; i < padCount; i++) {
+    padX[i] = tempPads[i].x; padY[i] = tempPads[i].y; padR[i] = tempPads[i].r
+  }
+
+  // Pack glows
+  const glowCount = Math.min(Math.floor(traceCount / 8), 20)
+  const glowX = new Float32Array(glowCount)
+  const glowY = new Float32Array(glowCount)
+  const glowR = new Float32Array(glowCount)
+  const glowPh = new Float32Array(glowCount)
+  const glowSp = new Float32Array(glowCount)
+  for (let i = 0; i < glowCount; i++) {
+    const ti = Math.floor(Math.random() * traceCount)
+    const startIdx = traceMeta[ti * 3]
+    const ptC = traceMeta[ti * 3 + 1]
+    const pi2 = Math.floor(Math.random() * ptC)
+    glowX[i] = tracePts[startIdx + pi2 * 2]
+    glowY[i] = tracePts[startIdx + pi2 * 2 + 1]
+    glowR[i] = 3 + Math.random() * 5
+    glowPh[i] = Math.random() * Math.PI * 2
+    glowSp[i] = 0.2 + Math.random() * 0.5
+  }
+
+  // Pack pulses
+  const pulses: PulseResult[] = []
+  if (!reducedMotion && traceCount > 0) {
+    const pc = Math.min(Math.floor(traceCount / 4), 24)
+    for (let i = 0; i < pc; i++) {
+      const ti = Math.floor(Math.random() * traceCount)
+      const startIdx = traceMeta[ti * 3]
+      const ptC = traceMeta[ti * 3 + 1]
+      if (ptC < 2) continue
+
+      const pts = new Float32Array(ptC * 2)
+      for (let j = 0; j < ptC * 2; j++) pts[j] = tracePts[startIdx + j]
+
+      const segLens = new Float32Array(ptC - 1)
+      let totalLen = 0
+      for (let j = 0; j < ptC - 1; j++) {
+        const ddx = pts[(j + 1) * 2] - pts[j * 2]
+        const ddy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+        const slen = Math.sqrt(ddx * ddx + ddy * ddy)
+        segLens[j] = slen
+        totalLen += slen
+      }
+
+      if (totalLen < 10) continue
+
+      const speedTier = Math.random()
+      const sp =
+        speedTier < 0.3
+          ? 0.0008 + Math.random() * 0.0007
+          : speedTier < 0.7
+          ? 0.002 + Math.random() * 0.002
+          : 0.005 + Math.random() * 0.004
+
+      pulses.push({
+        pts, segLens, totalLen,
+        pr: Math.random() * (1.0 + sp * 200),
+        sp,
+        ln: 0.04 + Math.random() * 0.06,
+        w: traceMeta[ti * 3 + 2],
+      })
+    }
+  }
+
+  const msg = {
+    id, traceCount, traceMeta, tracePts,
+    padCount, padX, padY, padR,
+    glowCount, glowX, glowY, glowR, glowPh, glowSp,
+    pulses,
+  }
+
+  const transfer = [
+    traceMeta.buffer, tracePts.buffer,
+    padX.buffer, padY.buffer, padR.buffer,
+    glowX.buffer, glowY.buffer, glowR.buffer, glowPh.buffer, glowSp.buffer,
+  ]
+
+  worker.postMessage(msg, transfer)
+}


### PR DESCRIPTION
## Summary

- Restores the PCB circuit board background from the reverted PR #6
- Generation runs in a Web Worker (`workers/circuit-generate.ts`) — zero main-thread blocking
- Main thread drives the `requestAnimationFrame` animation loop
- Mobile viewports (< 768px) get 40% interior seed density; edge seeding is unchanged so borders stay lively

## Approach

Simpler alternative to PR #7 (OffscreenCanvas). No browser compatibility concerns — works on all modern browsers including older iOS Safari. The trade-off is the animation loop runs on the main thread, but at 30fps with canvas batching this is negligible in practice.

## Test plan

- [ ] Circuit animates in dark and light mode
- [ ] Theme toggle updates accent color
- [ ] Resize triggers regeneration after 300ms debounce
- [ ] Viewport < 768px has visibly fewer interior traces than desktop
- [ ] `prefers-reduced-motion` renders static circuit without pulse animation
- [ ] No main-thread jank visible in DevTools Performance tab