### PR TITLE
Expand circuit config panel with generation math controls

### DIFF
--- a/app/admin/(dashboard)/circuit/page.tsx
+++ b/app/admin/(dashboard)/circuit/page.tsx
@@ -22,8 +22,8 @@ function Slider({ label, value, min, max, step, onChange, format }: SliderProps)
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between">
-        <span className="font-mono text-[13px] text-text-secondary">{label}</span>
-        <span className="font-mono text-[13px] text-accent tabular-nums">
+        <span className="font-mono text-[12px] text-text-secondary">{label}</span>
+        <span className="font-mono text-[12px] text-accent tabular-nums">
           {format ? format(value) : value}
         </span>
       </div>
@@ -41,13 +41,49 @@ function Slider({ label, value, min, max, step, onChange, format }: SliderProps)
   )
 }
 
-// ── Section header ────────────────────────────────────────────────────────────
+// ── Section header (collapsible) ─────────────────────────────────────────────
 
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
+function Section({
+  label,
+  collapsed,
+  onToggle,
+  badge,
+  children,
+}: {
+  label: string
+  collapsed: boolean
+  onToggle: () => void
+  badge?: string
+  children: React.ReactNode
+}) {
   return (
-    <div className="space-y-3">
-      <p className="font-mono text-[11px] uppercase tracking-widest text-text-muted">{label}</p>
-      {children}
+    <div className="space-y-2">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <svg
+          width="8"
+          height="8"
+          viewBox="0 0 8 8"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          className={`text-text-muted transition-transform ${collapsed ? "" : "rotate-90"}`}
+        >
+          <polyline points="2,1 6,4 2,7" />
+        </svg>
+        <span className="font-mono text-[11px] uppercase tracking-widest text-text-muted">
+          {label}
+        </span>
+        {badge && (
+          <span className="rounded-sm bg-accent/15 px-1 py-px font-mono text-[9px] text-accent">
+            {badge}
+          </span>
+        )}
+      </button>
+      {!collapsed && <div className="space-y-2 pl-3.5">{children}</div>}
     </div>
   )
 }
@@ -60,15 +96,15 @@ function FpsPicker({ value, onChange }: { value: number; onChange: (v: number) =
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between">
-        <span className="font-mono text-[13px] text-text-secondary">Frame rate</span>
-        <span className="font-mono text-[13px] text-accent">{value} fps</span>
+        <span className="font-mono text-[12px] text-text-secondary">Frame rate</span>
+        <span className="font-mono text-[12px] text-accent">{value} fps</span>
       </div>
       <div className="flex gap-1.5">
         {FPS_OPTIONS.map((f) => (
           <button
             key={f}
             onClick={() => onChange(f)}
-            className={`flex-1 rounded border py-1 font-mono text-[12px] transition-colors ${
+            className={`flex-1 rounded border py-1 font-mono text-[11px] transition-colors ${
               value === f
                 ? "border-accent bg-accent/10 text-accent"
                 : "border-border text-text-muted hover:border-text-muted hover:text-text-secondary"
@@ -102,8 +138,8 @@ function DurationPicker({
   return (
     <div className="space-y-1.5">
       <div className="flex items-baseline justify-between">
-        <span className="font-mono text-[13px] text-text-secondary">Run time</span>
-        <span className="font-mono text-[13px] text-accent">
+        <span className="font-mono text-[12px] text-text-secondary">Run time</span>
+        <span className="font-mono text-[12px] text-accent">
           {value === null ? "∞" : `${value}m`}
         </span>
       </div>
@@ -112,7 +148,7 @@ function DurationPicker({
           <button
             key={label}
             onClick={() => onChange(v)}
-            className={`flex-1 rounded border py-1 font-mono text-[12px] transition-colors ${
+            className={`flex-1 rounded border py-1 font-mono text-[11px] transition-colors ${
               value === v
                 ? "border-accent bg-accent/10 text-accent"
                 : "border-border text-text-muted hover:border-text-muted hover:text-text-secondary"
@@ -131,7 +167,7 @@ function DurationPicker({
 const MIN_W = 260
 const MIN_H = 160
 const DEFAULT_W = 296
-const DEFAULT_H = 560
+const DEFAULT_H = 620
 
 export default function CircuitConfigPage() {
   // Panel geometry
@@ -139,7 +175,20 @@ export default function CircuitConfigPage() {
   const [py, setPy] = useState(64)
   const [pw, setPw] = useState(DEFAULT_W)
   const [ph, setPh] = useState(DEFAULT_H)
-  const [collapsed, setCollapsed] = useState(false)
+  const [panelCollapsed, setPanelCollapsed] = useState(false)
+
+  // Section collapse state
+  const [sections, setSections] = useState({
+    visual: true,
+    pulses: true,
+    pulsePhysics: false,
+    generation: false,
+    performance: true,
+  })
+
+  const toggleSection = useCallback((key: keyof typeof sections) => {
+    setSections((s) => ({ ...s, [key]: !s[key] }))
+  }, [])
 
   // Start right-anchored once window is available
   useEffect(() => {
@@ -176,7 +225,7 @@ export default function CircuitConfigPage() {
   }
   const onResizeUp = () => { resizeRef.current = null }
 
-  // ── Config values ──
+  // ── Config values (existing) ──
   const [traceAlpha, setTraceAlpha] = useState(0.06)
   const [traceWidth, setTraceWidth] = useState(1.0)
   const [padAlpha, setPadAlpha] = useState(0.07)
@@ -187,24 +236,72 @@ export default function CircuitConfigPage() {
   const [pulseSpeed, setPulseSpeed] = useState(1.0)
   const [fps, setFps] = useState(30)
   const [density, setDensity] = useState(1.0)
-  const [duration, setDuration] = useState<number | null>(null) // null = ∞
+  const [duration, setDuration] = useState<number | null>(null)
+
+  // ── Config values (new — glow rendering) ──
+  const [glowRadius, setGlowRadius] = useState(1.0)
+  const [glowSpeed, setGlowSpeed] = useState(1.0)
+
+  // ── Config values (new — pulse physics) ──
+  const [pulseTailMin, setPulseTailMin] = useState(0.04)
+  const [pulseTailMax, setPulseTailMax] = useState(0.10)
+  const [pulseHeadSize, setPulseHeadSize] = useState(8)
+  const [pulseSegments, setPulseSegments] = useState(8)
+
+  // ── Config values (new — generation) ──
+  const [gridSize, setGridSize] = useState(10)
+  const [straightness, setStraightness] = useState(0.93)
+  const [maxSteps, setMaxSteps] = useState(80)
+  const [maxPaths, setMaxPaths] = useState(2000)
+  const [bundleSizeMin, setBundleSizeMin] = useState(3)
+  const [bundleSizeMax, setBundleSizeMax] = useState(7)
+  const [pathLenMin, setPathLenMin] = useState(40)
+  const [pathLenMax, setPathLenMax] = useState(90)
+  const [branchChance, setBranchChance] = useState(0.5)
+  const [padChance, setPadChance] = useState(0.3)
+  const [padSizeMin, setPadSizeMin] = useState(1.5)
+  const [padSizeMax, setPadSizeMax] = useState(3.5)
+  const [seamSpacing, setSeamSpacing] = useState(8)
+  const [glowCount, setGlowCount] = useState(0) // 0 = auto
 
   const densityTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const durationTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingGen = useRef<Record<string, number> | null>(null)
+  const genTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Immediate dispatch for rendering-time params
   const handle = useCallback((key: string, setter: (v: number) => void) => (v: number) => {
     setter(v)
     dispatch({ [key]: v })
+  }, [])
+
+  // Debounced dispatch for generation params (400ms)
+  const handleGen = useCallback((key: string, setter: (v: number) => void) => (v: number) => {
+    setter(v)
+    pendingGen.current = { ...(pendingGen.current ?? {}), [key]: v }
+    if (genTimer.current) clearTimeout(genTimer.current)
+    genTimer.current = setTimeout(() => {
+      if (pendingGen.current) {
+        dispatch(pendingGen.current)
+        pendingGen.current = null
+      }
+    }, 400)
   }, [])
 
   const onTraceAlpha = handle("traceAlpha", setTraceAlpha)
   const onTraceWidth = handle("traceWidth", setTraceWidth)
   const onPadAlpha = handle("padAlpha", setPadAlpha)
   const onGlowIntensity = handle("glowIntensity", setGlowIntensity)
+  const onGlowRadius = handle("glowRadius", setGlowRadius)
+  const onGlowSpeed = handle("glowSpeed", setGlowSpeed)
   const onFadeStrength = handle("fadeStrength", setFadeStrength)
   const onMaxPulses = handle("maxPulses", setMaxPulses)
   const onPulseBrightness = handle("pulseBrightness", setPulseBrightness)
   const onPulseSpeed = handle("pulseSpeed", setPulseSpeed)
+  const onPulseTailMin = handle("pulseTailMin", setPulseTailMin)
+  const onPulseTailMax = handle("pulseTailMax", setPulseTailMax)
+  const onPulseHeadSize = handle("pulseHeadSize", setPulseHeadSize)
+  const onPulseSegments = handle("pulseSegments", setPulseSegments)
   const onFps = useCallback((v: number) => { setFps(v); dispatch({ fps: v }) }, [])
 
   const onDensity = useCallback((v: number) => {
@@ -216,25 +313,56 @@ export default function CircuitConfigPage() {
   const onDuration = useCallback((d: number | null) => {
     setDuration(d)
     if (durationTimer.current) clearTimeout(durationTimer.current)
-    // Always unpause first (in case a prior timer had stopped the loop)
     dispatch({ paused: false })
     if (d !== null) {
       durationTimer.current = setTimeout(() => dispatch({ paused: true }), d * 60 * 1000)
     }
   }, [])
 
+  // Generation param handlers (debounced)
+  const onGridSize = handleGen("gridSize", setGridSize)
+  const onStraightness = handleGen("straightness", setStraightness)
+  const onMaxSteps = handleGen("maxSteps", setMaxSteps)
+  const onMaxPaths = handleGen("maxPaths", setMaxPaths)
+  const onBundleSizeMin = handleGen("bundleSizeMin", setBundleSizeMin)
+  const onBundleSizeMax = handleGen("bundleSizeMax", setBundleSizeMax)
+  const onPathLenMin = handleGen("pathLenMin", setPathLenMin)
+  const onPathLenMax = handleGen("pathLenMax", setPathLenMax)
+  const onBranchChance = handleGen("branchChance", setBranchChance)
+  const onPadChance = handleGen("padChance", setPadChance)
+  const onPadSizeMin = handleGen("padSizeMin", setPadSizeMin)
+  const onPadSizeMax = handleGen("padSizeMax", setPadSizeMax)
+  const onSeamSpacing = handleGen("seamSpacing", setSeamSpacing)
+  const onGlowCount = handleGen("glowCount", setGlowCount)
+
   const handleReset = () => {
+    // Existing
     setTraceAlpha(0.06); setTraceWidth(1.0); setPadAlpha(0.07)
     setGlowIntensity(1.0); setFadeStrength(0.65); setMaxPulses(24)
     setPulseBrightness(1.0); setPulseSpeed(1.0); setFps(30); setDensity(1.0)
     setDuration(null)
+    // New rendering
+    setGlowRadius(1.0); setGlowSpeed(1.0)
+    // New pulse physics
+    setPulseTailMin(0.04); setPulseTailMax(0.10)
+    setPulseHeadSize(8); setPulseSegments(8)
+    // New generation
+    setGridSize(10); setStraightness(0.93); setMaxSteps(80); setMaxPaths(2000)
+    setBundleSizeMin(3); setBundleSizeMax(7); setPathLenMin(40); setPathLenMax(90)
+    setBranchChance(0.5); setPadChance(0.3); setPadSizeMin(1.5); setPadSizeMax(3.5)
+    setSeamSpacing(8); setGlowCount(0)
+    // Clear timers
     if (durationTimer.current) clearTimeout(durationTimer.current)
+    if (genTimer.current) clearTimeout(genTimer.current)
+    pendingGen.current = null
     dispatch({ reset: true })
   }
 
   const pct = (v: number) => `${Math.round(v * 100)}%`
   const mult = (v: number) => `${v.toFixed(2)}×`
   const fixed2 = (v: number) => v.toFixed(2)
+  const fixed3 = (v: number) => v.toFixed(3)
+  const int = (v: number) => String(Math.round(v))
 
   return (
     <>
@@ -271,12 +399,12 @@ export default function CircuitConfigPage() {
               reset
             </button>
             <button
-              onClick={() => setCollapsed(c => !c)}
+              onClick={() => setPanelCollapsed(c => !c)}
               className="flex h-5 w-5 items-center justify-center rounded text-text-muted transition-colors hover:text-text-primary"
-              title={collapsed ? "Expand" : "Collapse"}
+              title={panelCollapsed ? "Expand" : "Collapse"}
             >
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                {collapsed
+                {panelCollapsed
                   ? <><line x1="2" y1="3" x2="5" y2="7"/><line x1="5" y1="7" x2="8" y2="3"/></>
                   : <><line x1="2" y1="7" x2="5" y2="3"/><line x1="5" y1="3" x2="8" y2="7"/></>
                 }
@@ -286,40 +414,76 @@ export default function CircuitConfigPage() {
         </div>
 
         {/* Body */}
-        {!collapsed && (
+        {!panelCollapsed && (
           <div
             style={{ height: ph, overflowY: "auto" }}
-            className="space-y-5 p-4"
+            className="space-y-4 p-4"
           >
-            <Section label="Visual">
+            {/* ── Visual ── */}
+            <Section label="Visual" collapsed={!sections.visual} onToggle={() => toggleSection("visual")}>
               <Slider label="Trace opacity" value={traceAlpha} min={0} max={0.4} step={0.005} onChange={onTraceAlpha} format={pct} />
               <Slider label="Trace width" value={traceWidth} min={0.2} max={4} step={0.05} onChange={onTraceWidth} format={mult} />
               <Slider label="Pad opacity" value={padAlpha} min={0} max={0.4} step={0.005} onChange={onPadAlpha} format={pct} />
               <Slider label="Glow intensity" value={glowIntensity} min={0} max={3} step={0.05} onChange={onGlowIntensity} format={mult} />
+              <Slider label="Glow radius" value={glowRadius} min={0.1} max={5} step={0.05} onChange={onGlowRadius} format={mult} />
+              <Slider label="Glow speed" value={glowSpeed} min={0} max={5} step={0.05} onChange={onGlowSpeed} format={mult} />
               <Slider label="Vignette" value={fadeStrength} min={0} max={1} step={0.01} onChange={onFadeStrength} format={fixed2} />
             </Section>
 
             <div className="border-t border-border/50" />
 
-            <Section label="Pulses">
-              <Slider label="Count" value={maxPulses} min={0} max={48} step={1} onChange={onMaxPulses} format={String} />
+            {/* ── Pulses ── */}
+            <Section label="Pulses" collapsed={!sections.pulses} onToggle={() => toggleSection("pulses")}>
+              <Slider label="Count" value={maxPulses} min={0} max={48} step={1} onChange={onMaxPulses} format={int} />
               <Slider label="Brightness" value={pulseBrightness} min={0} max={3} step={0.05} onChange={onPulseBrightness} format={mult} />
               <Slider label="Speed" value={pulseSpeed} min={0.05} max={6} step={0.05} onChange={onPulseSpeed} format={mult} />
             </Section>
 
             <div className="border-t border-border/50" />
 
-            <Section label="Performance">
+            {/* ── Pulse Physics ── */}
+            <Section label="Pulse Physics" collapsed={!sections.pulsePhysics} onToggle={() => toggleSection("pulsePhysics")}>
+              <Slider label="Tail min" value={pulseTailMin} min={0.005} max={0.5} step={0.005} onChange={onPulseTailMin} format={fixed3} />
+              <Slider label="Tail max" value={pulseTailMax} min={0.005} max={0.5} step={0.005} onChange={onPulseTailMax} format={fixed3} />
+              <Slider label="Head size" value={pulseHeadSize} min={1} max={30} step={1} onChange={onPulseHeadSize} format={int} />
+              <Slider label="Trail segments" value={pulseSegments} min={2} max={24} step={1} onChange={onPulseSegments} format={int} />
+            </Section>
+
+            <div className="border-t border-border/50" />
+
+            {/* ── Generation ── */}
+            <Section label="Generation" collapsed={!sections.generation} onToggle={() => toggleSection("generation")} badge="regen">
+              <p className="font-mono text-[10px] text-text-muted">Changes trigger full regeneration (400ms debounce)</p>
+              <Slider label="Grid size" value={gridSize} min={2} max={50} step={1} onChange={onGridSize} format={int} />
+              <Slider label="Straightness" value={straightness} min={0} max={1} step={0.01} onChange={onStraightness} format={fixed2} />
+              <Slider label="Growth steps" value={maxSteps} min={1} max={500} step={1} onChange={onMaxSteps} format={int} />
+              <Slider label="Max paths" value={maxPaths} min={50} max={5000} step={50} onChange={onMaxPaths} format={int} />
+              <Slider label="Bundle min" value={bundleSizeMin} min={1} max={20} step={1} onChange={onBundleSizeMin} format={int} />
+              <Slider label="Bundle max" value={bundleSizeMax} min={1} max={20} step={1} onChange={onBundleSizeMax} format={int} />
+              <Slider label="Path len min" value={pathLenMin} min={3} max={200} step={1} onChange={onPathLenMin} format={int} />
+              <Slider label="Path len max" value={pathLenMax} min={3} max={200} step={1} onChange={onPathLenMax} format={int} />
+              <Slider label="Branch chance" value={branchChance} min={0} max={1} step={0.01} onChange={onBranchChance} format={fixed2} />
+              <Slider label="Pad chance" value={padChance} min={0} max={1} step={0.01} onChange={onPadChance} format={fixed2} />
+              <Slider label="Pad size min" value={padSizeMin} min={0.5} max={10} step={0.1} onChange={onPadSizeMin} format={fixed2} />
+              <Slider label="Pad size max" value={padSizeMax} min={0.5} max={10} step={0.1} onChange={onPadSizeMax} format={fixed2} />
+              <Slider label="Seam spacing" value={seamSpacing} min={2} max={30} step={1} onChange={onSeamSpacing} format={int} />
+              <Slider label="Glow count" value={glowCount} min={0} max={40} step={1} onChange={onGlowCount} format={(v) => v === 0 ? "auto" : String(v)} />
+            </Section>
+
+            <div className="border-t border-border/50" />
+
+            {/* ── Performance ── */}
+            <Section label="Performance" collapsed={!sections.performance} onToggle={() => toggleSection("performance")}>
               <FpsPicker value={fps} onChange={onFps} />
               <DurationPicker value={duration} onChange={onDuration} />
               <Slider label="Density" value={density} min={0.1} max={2.0} step={0.05} onChange={onDensity} format={fixed2} />
-              <p className="font-mono text-[11px] text-text-muted">Density triggers regen after 400 ms</p>
+              <p className="font-mono text-[10px] text-text-muted">Density triggers regen after 400 ms</p>
             </Section>
           </div>
         )}
 
         {/* Resize handle — bottom-right corner */}
-        {!collapsed && (
+        {!panelCollapsed && (
           <div
             onPointerDown={onResizeDown}
             onPointerMove={onResizeMove}

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -76,6 +76,32 @@ let pulseBrightnessMult = 1.0
 let pulseSpeedMult = 1.0
 let traceWidthMult = 1.0
 
+// Generation math overrides (trigger regen)
+let gridSizeOverride: number | null = null
+let straightnessOverride: number | null = null
+let maxStepsOverride: number | null = null
+let maxPathsOverride: number | null = null
+let bundleSizeMinOverride: number | null = null
+let bundleSizeMaxOverride: number | null = null
+let pathLenMinOverride: number | null = null
+let pathLenMaxOverride: number | null = null
+let branchChanceOverride: number | null = null
+let padChanceOverride: number | null = null
+let padSizeMinOverride: number | null = null
+let padSizeMaxOverride: number | null = null
+let seamSpacingOverride: number | null = null
+let glowCountOverride: number | null = null
+
+// Glow rendering overrides
+let glowRadiusMult = 1.0
+let glowSpeedMult = 1.0
+
+// Pulse physics overrides
+let pulseTailMinOverride: number | null = null
+let pulseTailMaxOverride: number | null = null
+let pulseHeadSizeOverride: number | null = null
+let pulseSegmentsOverride: number | null = null
+
 let w = 0
 let h = 0
 let dpr = 1
@@ -119,7 +145,7 @@ const DX = [1, 0, -1, 0, 1, -1, -1, 1]
 const DY = [0, 1, 0, -1, 1, 1, -1, -1]
 
 function generate(gw: number, gh: number, rm: boolean, density: number) {
-  const gridSize = 10
+  const gridSize = gridSizeOverride ?? 10
   const cols = Math.ceil(gw / gridSize)
   const rows = Math.ceil(gh / gridSize)
   const grid = new Uint8Array(cols * rows)
@@ -134,7 +160,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
 
   // ── Path storage ──
 
-  const MAX_PATHS = 2000
+  const MAX_PATHS = maxPathsOverride ?? 2000
   const MAX_HISTORY = 100
   const px = new Int16Array(MAX_PATHS)
   const py = new Int16Array(MAX_PATHS)
@@ -159,8 +185,12 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   }
 
   function seedBundle(startX: number, startY: number, dir: number, perpDx: number, perpDy: number) {
-    const bundleSize = 3 + Math.floor(Math.random() * 5)
-    const pathLen = 40 + Math.floor(Math.random() * 50)
+    const bMin = bundleSizeMinOverride ?? 3
+    const bMax = bundleSizeMaxOverride ?? 7
+    const bundleSize = bMin + Math.floor(Math.random() * (bMax - bMin + 1))
+    const plMin = pathLenMinOverride ?? 40
+    const plMax = pathLenMaxOverride ?? 90
+    const pathLen = plMin + Math.floor(Math.random() * (plMax - plMin))
     const bw = 0.6 + Math.random() * 0.5
     for (let i = 0; i < bundleSize; i++) {
       seedPath(startX + perpDx * i, startY + perpDy * i, dir, pathLen, bw)
@@ -177,7 +207,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   // All other generation branches out independently from the stub endpoints.
 
   const seamRows = Math.max(3, Math.ceil(rows * 0.05))
-  const seamStep = 8  // one stub pair every 8 grid columns (~80 px)
+  const seamStep = seamSpacingOverride ?? 8  // one stub pair every N grid columns
 
   for (let sx = 4; sx < cols - 4; sx += seamStep) {
     const sw = 0.5 + ((sx * 3 + 7) % 15) / 30  // deterministic width 0.5..1.0
@@ -222,8 +252,10 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(0, y, 0, 0, 1)
   for (let y = 3; y < rows - 10; y += 6 + Math.floor(Math.random() * 6)) seedBundle(cols - 1, y, 2, 0, 1)
   for (let y = 2; y < rows - 2; y += 4 + Math.floor(Math.random() * 3)) {
-    seedPath(0, y, 0, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
-    seedPath(cols - 1, y, 2, 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.5)
+    const eplMin = pathLenMinOverride ?? 30
+    const eplMax = pathLenMaxOverride ?? 70
+    seedPath(0, y, 0, eplMin + Math.floor(Math.random() * (eplMax - eplMin)), 0.5 + Math.random() * 0.5)
+    seedPath(cols - 1, y, 2, eplMin + Math.floor(Math.random() * (eplMax - eplMin)), 0.5 + Math.random() * 0.5)
   }
 
   // Interior seeds (density-scaled)
@@ -241,13 +273,15 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   for (let i = 0; i < intSeeds; i++) {
     const x = 3 + Math.floor(Math.random() * (cols - 6))
     const y = 3 + Math.floor(Math.random() * (rows - 6))
-    seedPath(x, y, Math.floor(Math.random() * 4), 30 + Math.floor(Math.random() * 40), 0.5 + Math.random() * 0.8)
+    const iplMin = pathLenMinOverride ?? 30
+    const iplMax = pathLenMaxOverride ?? 70
+    seedPath(x, y, Math.floor(Math.random() * 4), iplMin + Math.floor(Math.random() * (iplMax - iplMin)), 0.5 + Math.random() * 0.8)
   }
 
   // ── Round-robin growth ──
 
-  const STRAIGHTNESS = 0.93
-  const maxSteps = 80
+  const STRAIGHTNESS = straightnessOverride ?? 0.93
+  const maxSteps = maxStepsOverride ?? 80
   const shuffleArr = new Uint16Array(MAX_PATHS)
 
   for (let step = 0; step < maxSteps; step++) {
@@ -286,7 +320,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
         pblocked[pi]++
         if (pblocked[pi] >= 2) {
           palive[pi] = 0
-          if (phistLen[pi] > 4 && Math.random() < 0.5) {
+          if (phistLen[pi] > 4 && Math.random() < (branchChanceOverride ?? 0.5)) {
             const perpDir = (pdir[pi] + (Math.random() < 0.5 ? 1 : 3)) % 4
             seedPath(px[pi] + DX[perpDir], py[pi] + DY[perpDir], perpDir, 8 + Math.floor(Math.random() * 15), pwidth[pi] * 0.8)
           }
@@ -334,13 +368,15 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
 
     if (simplified.length >= 4) {
       tempTraces.push({ pts: simplified, w: pwidth[pi] })
+      const psMin = padSizeMinOverride ?? 1.5
+      const psMax = padSizeMaxOverride ?? 3.5
       tempPads.push({
         x: simplified[simplified.length - 2],
         y: simplified[simplified.length - 1],
-        r: 1.5 + Math.random() * 2,
+        r: psMin + Math.random() * (psMax - psMin),
       })
-      if (Math.random() < 0.3) {
-        tempPads.push({ x: simplified[0], y: simplified[1], r: 1.5 + Math.random() * 1.5 })
+      if (Math.random() < (padChanceOverride ?? 0.3)) {
+        tempPads.push({ x: simplified[0], y: simplified[1], r: psMin + Math.random() * (psMax - psMin) * 0.75 })
       }
     }
   }
@@ -371,7 +407,7 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
   }
 
   // Pack glows
-  const gc = Math.min(Math.floor(tc / 8), 20)
+  const gc = glowCountOverride ?? Math.min(Math.floor(tc / 8), 20)
   const gx = new Float32Array(gc)
   const gy = new Float32Array(gc)
   const gr = new Float32Array(gc)
@@ -428,13 +464,15 @@ function generate(gw: number, gh: number, rm: boolean, density: number) {
           ? 0.002 + Math.random() * 0.002
           : 0.005 + Math.random() * 0.004
 
+      const ptlMin = pulseTailMinOverride ?? 0.04
+      const ptlMax = pulseTailMaxOverride ?? 0.10
       pulses.push({
         pts,
         segLens,
         totalLen,
         pr: Math.random() * (1.0 + sp * 200),
         sp,
-        ln: 0.04 + Math.random() * 0.06,
+        ln: ptlMin + Math.random() * (ptlMax - ptlMin),
         w: tm[ti * 3 + 2],
         ti,
       })
@@ -507,7 +545,9 @@ function resamplePulse(pl: PulseData) {
   pl.segLens = segLens
   pl.totalLen = totalLen
   pl.w = traceMeta[ti * 3 + 2]
-  pl.ln = 0.04 + Math.random() * 0.06
+  const rptlMin = pulseTailMinOverride ?? 0.04
+  const rptlMax = pulseTailMaxOverride ?? 0.10
+  pl.ln = rptlMin + Math.random() * (rptlMax - rptlMin)
   pl.ti = ti
 }
 
@@ -580,8 +620,8 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
   // Glows
   const glowMult = isLightMode ? 1.0 : 0.8
   for (let i = 0; i < glowCount; i++) {
-    const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] + glowPh[i]) * 0.3
-    const radius = glowR[i] * 5
+    const pulse = reducedMotion ? 0.6 : 0.4 + Math.sin(t * glowSp[i] * glowSpeedMult + glowPh[i]) * 0.3
+    const radius = glowR[i] * 5 * glowRadiusMult
     const gradR = ctx.createRadialGradient(glowX[i], glowY[i], 0, glowX[i], glowY[i], radius)
     gradR.addColorStop(0, `rgba(${r},${g},${b},${(0.2 * pulse * glowMult * glowIntensityMult).toFixed(3)})`)
     gradR.addColorStop(0.5, `rgba(${r},${g},${b},${(0.06 * pulse * glowMult * glowIntensityMult).toFixed(3)})`)
@@ -599,11 +639,12 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
   // Pulses (desktop only, pre-computed states — no position advancement here)
   for (const { pl, life, hd, td } of drawablePulses) {
     const pulseMult = (isLightMode ? 0.8 : 0.7) * life * pulseBrightnessMult
+    const segs = pulseSegmentsOverride ?? 8
     ctx.lineCap = "round"
-    for (let s = 0; s < 8; s++) {
-      const f = s / 8
+    for (let s = 0; s < segs; s++) {
+      const f = s / segs
       const [x1, y1] = ptAt(pl, td + (hd - td) * f)
-      const [x2, y2] = ptAt(pl, td + (hd - td) * ((s + 1) / 8))
+      const [x2, y2] = ptAt(pl, td + (hd - td) * ((s + 1) / segs))
       ctx.beginPath()
       ctx.moveTo(x1, y1)
       ctx.lineTo(x2, y2)
@@ -613,13 +654,14 @@ function drawScene(time: number, drawablePulses: DrawablePulse[]) {
     }
     const [hx, hy] = ptAt(pl, hd)
     const headAlpha = 0.5 * life
-    const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, 8)
+    const headR = pulseHeadSizeOverride ?? 8
+    const headGrad = ctx.createRadialGradient(hx, hy, 0, hx, hy, headR)
     headGrad.addColorStop(0, `rgba(${r},${g},${b},${headAlpha})`)
     headGrad.addColorStop(0.3, `rgba(${r},${g},${b},${(headAlpha * 0.4).toFixed(3)})`)
     headGrad.addColorStop(1, `rgba(${r},${g},${b},0)`)
     ctx.fillStyle = headGrad
     ctx.beginPath()
-    ctx.arc(hx, hy, 8, 0, 6.2832)
+    ctx.arc(hx, hy, headR, 0, 6.2832)
     ctx.fill()
   }
 
@@ -691,7 +733,7 @@ function stopLoop() {
     | { type: "init"; canvas: OffscreenCanvas; w: number; h: number; dpr: number; reducedMotion: boolean; theme: Theme; accent: string; density: number }
     | { type: "resize"; w: number; h: number; dpr: number; density: number }
     | { type: "theme"; theme: Theme; accent: string }
-    | { type: "config"; reset?: boolean; paused?: boolean; density?: number; traceAlpha?: number; padAlpha?: number; fadeStrength?: number; maxPulses?: number; fps?: number; glowIntensity?: number; pulseBrightness?: number; pulseSpeed?: number; traceWidth?: number }
+    | { type: "config"; reset?: boolean; paused?: boolean; density?: number; traceAlpha?: number; padAlpha?: number; fadeStrength?: number; maxPulses?: number; fps?: number; glowIntensity?: number; pulseBrightness?: number; pulseSpeed?: number; traceWidth?: number; glowRadius?: number; glowSpeed?: number; pulseTailMin?: number; pulseTailMax?: number; pulseHeadSize?: number; pulseSegments?: number; gridSize?: number; straightness?: number; maxSteps?: number; maxPaths?: number; bundleSizeMin?: number; bundleSizeMax?: number; pathLenMin?: number; pathLenMax?: number; branchChance?: number; padChance?: number; padSizeMin?: number; padSizeMax?: number; seamSpacing?: number; glowCount?: number }
   >
 ) => {
   const msg = e.data
@@ -741,6 +783,26 @@ function stopLoop() {
       pulseBrightnessMult = 1.0
       pulseSpeedMult = 1.0
       traceWidthMult = 1.0
+      glowRadiusMult = 1.0
+      glowSpeedMult = 1.0
+      gridSizeOverride = null
+      straightnessOverride = null
+      maxStepsOverride = null
+      maxPathsOverride = null
+      bundleSizeMinOverride = null
+      bundleSizeMaxOverride = null
+      pathLenMinOverride = null
+      pathLenMaxOverride = null
+      branchChanceOverride = null
+      padChanceOverride = null
+      padSizeMinOverride = null
+      padSizeMaxOverride = null
+      seamSpacingOverride = null
+      glowCountOverride = null
+      pulseTailMinOverride = null
+      pulseTailMaxOverride = null
+      pulseHeadSizeOverride = null
+      pulseSegmentsOverride = null
       currentDensity = w < 768 ? 0.6 : 1.0
       const defaultTraceAlpha = isLightMode ? 0.11 : 0.06
       const defaultPadAlpha = isLightMode ? 0.13 : 0.07
@@ -771,6 +833,28 @@ function stopLoop() {
     if (msg.pulseBrightness !== undefined) pulseBrightnessMult = msg.pulseBrightness
     if (msg.pulseSpeed !== undefined) pulseSpeedMult = msg.pulseSpeed
     if (msg.traceWidth !== undefined) traceWidthMult = msg.traceWidth
+    // Rendering-time overrides (immediate, no regen)
+    if (msg.glowRadius !== undefined) glowRadiusMult = msg.glowRadius
+    if (msg.glowSpeed !== undefined) glowSpeedMult = msg.glowSpeed
+    if (msg.pulseTailMin !== undefined) pulseTailMinOverride = msg.pulseTailMin
+    if (msg.pulseTailMax !== undefined) pulseTailMaxOverride = msg.pulseTailMax
+    if (msg.pulseHeadSize !== undefined) pulseHeadSizeOverride = msg.pulseHeadSize
+    if (msg.pulseSegments !== undefined) pulseSegmentsOverride = msg.pulseSegments
+    // Generation overrides (trigger regen)
+    if (msg.gridSize !== undefined) { gridSizeOverride = msg.gridSize; needsRegen = true }
+    if (msg.straightness !== undefined) { straightnessOverride = msg.straightness; needsRegen = true }
+    if (msg.maxSteps !== undefined) { maxStepsOverride = msg.maxSteps; needsRegen = true }
+    if (msg.maxPaths !== undefined) { maxPathsOverride = msg.maxPaths; needsRegen = true }
+    if (msg.bundleSizeMin !== undefined) { bundleSizeMinOverride = msg.bundleSizeMin; needsRegen = true }
+    if (msg.bundleSizeMax !== undefined) { bundleSizeMaxOverride = msg.bundleSizeMax; needsRegen = true }
+    if (msg.pathLenMin !== undefined) { pathLenMinOverride = msg.pathLenMin; needsRegen = true }
+    if (msg.pathLenMax !== undefined) { pathLenMaxOverride = msg.pathLenMax; needsRegen = true }
+    if (msg.branchChance !== undefined) { branchChanceOverride = msg.branchChance; needsRegen = true }
+    if (msg.padChance !== undefined) { padChanceOverride = msg.padChance; needsRegen = true }
+    if (msg.padSizeMin !== undefined) { padSizeMinOverride = msg.padSizeMin; needsRegen = true }
+    if (msg.padSizeMax !== undefined) { padSizeMaxOverride = msg.padSizeMax; needsRegen = true }
+    if (msg.seamSpacing !== undefined) { seamSpacingOverride = msg.seamSpacing; needsRegen = true }
+    if (msg.glowCount !== undefined) { glowCountOverride = msg.glowCount === 0 ? null : msg.glowCount; needsRegen = true }
     if (needsRegen) { stopLoop(); ready = false; generate(w, h, reducedMotion, currentDensity); startLoop() }
     else if (reducedMotion && ready) draw(performance.now())
     return


### PR DESCRIPTION
## Summary
- 30 controls across 5 collapsible sections: Visual, Pulses, Pulse Physics, Generation, Performance
- Generation section exposes core math: grid size, straightness, growth steps, max paths, bundle size, path length, branch chance, pad chance/size, seam spacing, glow count
- Slider ranges intentionally wide (e.g. grid size 2–50, max paths 50–5000) — designed to let you break things
- Generation params batched with 400ms debounce to avoid excessive regens
- Rendering-time params (glow radius/speed, pulse physics) update instantly

## New controls
| Section | Controls |
|---------|----------|
| **Visual** | trace opacity, trace width, pad opacity, glow intensity, glow radius, glow speed, vignette |
| **Pulses** | count, brightness, speed |
| **Pulse Physics** | tail min/max, head size, trail segments |
| **Generation** | grid size, straightness, growth steps, max paths, bundle min/max, path len min/max, branch chance, pad chance, pad size min/max, seam spacing, glow count |
| **Performance** | FPS, duration, density |