### PR TITLE
Add cursor-responsive hover glow and click-to-pulse to circuit bg

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@ body {
   }
 
   @keyframes circuit-tile-scroll {
-    to { transform: translateY(-50%); }
+    to { transform: translateY(var(--circuit-max-translate, -50%)); }
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Syne, DM_Sans, JetBrains_Mono } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Sidebar } from "@/components/sidebar"
 import { ChatPanelLazy } from "@/components/chat-panel-lazy"
-import { CursorGlow } from "@/components/cursor-glow"
+
 import { Analytics } from "@vercel/analytics/react"
 import { CircuitBgLazy } from "@/components/circuit-bg-lazy"
 import { PrefetchRoutes } from "@/components/prefetch-routes"
@@ -129,7 +129,6 @@ export default async function RootLayout({
             <>{children}</>
           ) : (
             <>
-              <CursorGlow />
               <Sidebar />
               <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
                 <CircuitBgLazy navOffset />

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -97,7 +97,34 @@ export function CircuitBg({ navOffset }: { navOffset?: boolean } = {}) {
       }
       window.addEventListener("circuit-config", onConfig)
 
+      // ── Scroll-travel capping ─────────────────────────────────────────
+      // The CSS scroll-driven animation maps 0–100% scroll progress to
+      // translateY(var(--circuit-max-translate)). On short pages we cap the
+      // travel so the background doesn't zoom past at high speed.
+      const updateScrollTravel = () => {
+        const scrollable = document.documentElement.scrollHeight - window.innerHeight
+        if (scrollable <= 0) {
+          canvas.style.setProperty("--circuit-max-translate", "0%")
+          return
+        }
+        const ratio = Math.min(scrollable / window.innerHeight, 1)
+        canvas.style.setProperty("--circuit-max-translate", `${(-ratio * 50).toFixed(2)}%`)
+      }
+      updateScrollTravel()
+
+      const bodyResizeObs = new ResizeObserver(updateScrollTravel)
+      bodyResizeObs.observe(document.body)
+
       // ── Cursor responsiveness ────────────────────────────────────────────
+      const getScrollOffsetY = () => {
+        const scrollable = document.documentElement.scrollHeight - window.innerHeight
+        if (scrollable <= 0) return 0
+        const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
+        const progress = Math.min(scrollTop / scrollable, 1)
+        const maxTravelPx = Math.min(scrollable, window.innerHeight)
+        return progress * maxTravelPx
+      }
+
       let lastPointerSend = 0
       const translateX = (clientX: number) =>
         navOffset && window.innerWidth >= 768 ? clientX - 240 : clientX
@@ -106,10 +133,10 @@ export function CircuitBg({ navOffset }: { navOffset?: boolean } = {}) {
         const now = performance.now()
         if (now - lastPointerSend < 33) return // ~30fps throttle
         lastPointerSend = now
-        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY, pressed: false })
+        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY + getScrollOffsetY(), pressed: false })
       }
       const onClick = (e: MouseEvent) => {
-        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY, pressed: true })
+        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY + getScrollOffsetY(), pressed: true })
       }
       window.addEventListener("mousemove", onMouseMove)
       window.addEventListener("click", onClick)
@@ -120,6 +147,7 @@ export function CircuitBg({ navOffset }: { navOffset?: boolean } = {}) {
         window.removeEventListener("circuit-config", onConfig)
         window.removeEventListener("mousemove", onMouseMove)
         window.removeEventListener("click", onClick)
+        bodyResizeObs.disconnect()
         obs.disconnect()
         worker.terminate()
       }

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -97,10 +97,29 @@ export function CircuitBg({ navOffset }: { navOffset?: boolean } = {}) {
       }
       window.addEventListener("circuit-config", onConfig)
 
+      // ── Cursor responsiveness ────────────────────────────────────────────
+      let lastPointerSend = 0
+      const translateX = (clientX: number) =>
+        navOffset && window.innerWidth >= 768 ? clientX - 240 : clientX
+
+      const onMouseMove = (e: MouseEvent) => {
+        const now = performance.now()
+        if (now - lastPointerSend < 33) return // ~30fps throttle
+        lastPointerSend = now
+        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY, pressed: false })
+      }
+      const onClick = (e: MouseEvent) => {
+        worker.postMessage({ type: "pointer", x: translateX(e.clientX), y: e.clientY, pressed: true })
+      }
+      window.addEventListener("mousemove", onMouseMove)
+      window.addEventListener("click", onClick)
+
       return () => {
         clearTimeout(rt)
         window.removeEventListener("resize", onResize)
         window.removeEventListener("circuit-config", onConfig)
+        window.removeEventListener("mousemove", onMouseMove)
+        window.removeEventListener("click", onClick)
         obs.disconnect()
         worker.terminate()
       }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -579,11 +579,15 @@ function spawnClickPulse(x: number, y: number) {
     ? 0.003 + Math.random() * 0.004
     : 0.008 + Math.random() * 0.006
 
+  // Clamp start position so the pulse always has at least 30% of the
+  // path left to travel — avoids spawning at the destination.
+  const pr = Math.min(nearest.distAlongPath, 0.7)
+
   clickPulses.push({
     pts,
     segLens,
     totalLen,
-    pr: nearest.distAlongPath,
+    pr,
     sp,
     ln: 0.08,
     w: traceMeta[ti * 3 + 2],
@@ -741,33 +745,49 @@ function draw(time: number) {
   drawScene(time, drawablePulses)
   ctx.restore()
 
-  // ── Trace proximity highlight (segment-level, viewport space) ──────
+  // ── Trace proximity highlight (segment-level, both tiles) ──────────
   if (mouseActive && mouseX >= 0) {
-    const highlightRadius = 100
+    const highlightRadius = 200
     const hrSq = highlightRadius * highlightRadius
-    const baseAlpha = isLightMode ? 0.15 : 0.10
-    ctx.strokeStyle = `rgba(${cachedR},${cachedG},${cachedB},${baseAlpha})`
+    const maxAlpha = isLightMode ? 0.44 : 0.33
+    const tileMouseY = ((mouseY % h) + h) % h
     ctx.lineCap = "round"
     ctx.lineJoin = "round"
-    for (let i = 0; i < traceCount; i++) {
-      const startIdx = traceMeta[i * 3]
-      const ptCount = traceMeta[i * 3 + 1]
-      ctx.lineWidth = traceMeta[i * 3 + 2] * traceWidthMult
-      let inSegment = false
-      for (let j = 0; j < ptCount; j++) {
-        const px = tracePts[startIdx + j * 2]
-        const py = tracePts[startIdx + j * 2 + 1]
-        const dx = px - mouseX, dy = py - mouseY
-        const near = dx * dx + dy * dy < hrSq
-        if (near) {
-          if (!inSegment) { ctx.beginPath(); ctx.moveTo(px, py); inSegment = true }
-          else ctx.lineTo(px, py)
-        } else {
-          // One extra segment past the boundary for a smooth exit
-          if (inSegment) { ctx.lineTo(px, py); ctx.stroke(); inSegment = false }
+
+    for (let tile = 0; tile < 2; tile++) {
+      const yOff = tile * h
+      for (let i = 0; i < traceCount; i++) {
+        const startIdx = traceMeta[i * 3]
+        const ptCount = traceMeta[i * 3 + 1]
+        ctx.lineWidth = traceMeta[i * 3 + 2] * traceWidthMult
+
+        for (let j = 0; j < ptCount - 1; j++) {
+          const px1 = tracePts[startIdx + j * 2]
+          const py1 = tracePts[startIdx + j * 2 + 1]
+          const px2 = tracePts[startIdx + (j + 1) * 2]
+          const py2 = tracePts[startIdx + (j + 1) * 2 + 1]
+
+          // Use midpoint of segment for distance calc
+          const mx = (px1 + px2) * 0.5
+          const my = (py1 + py2) * 0.5
+          const dx = mx - mouseX
+          const dy = my - tileMouseY
+          const distSq = dx * dx + dy * dy
+
+          if (distSq >= hrSq) continue
+
+          // Smooth falloff: 1.0 at center, 0.0 at edge (quadratic)
+          const dist = Math.sqrt(distSq)
+          const t = 1 - dist / highlightRadius
+          const alpha = maxAlpha * t * t
+
+          ctx.strokeStyle = `rgba(${cachedR},${cachedG},${cachedB},${alpha.toFixed(3)})`
+          ctx.beginPath()
+          ctx.moveTo(px1, py1 + yOff)
+          ctx.lineTo(px2, py2 + yOff)
+          ctx.stroke()
         }
       }
-      if (inSegment) ctx.stroke()
     }
   }
 
@@ -831,7 +851,7 @@ function stopLoop() {
   if (msg.type === "pointer") {
     mouseX = msg.x
     mouseY = msg.y
-    if (msg.pressed) spawnClickPulse(msg.x, msg.y)
+    if (msg.pressed) spawnClickPulse(msg.x, ((msg.y % h) + h) % h)
     mouseActive = true
     return
   }

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -741,6 +741,36 @@ function draw(time: number) {
   drawScene(time, drawablePulses)
   ctx.restore()
 
+  // ── Trace proximity highlight (segment-level, viewport space) ──────
+  if (mouseActive && mouseX >= 0) {
+    const highlightRadius = 100
+    const hrSq = highlightRadius * highlightRadius
+    const baseAlpha = isLightMode ? 0.15 : 0.10
+    ctx.strokeStyle = `rgba(${cachedR},${cachedG},${cachedB},${baseAlpha})`
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+    for (let i = 0; i < traceCount; i++) {
+      const startIdx = traceMeta[i * 3]
+      const ptCount = traceMeta[i * 3 + 1]
+      ctx.lineWidth = traceMeta[i * 3 + 2] * traceWidthMult
+      let inSegment = false
+      for (let j = 0; j < ptCount; j++) {
+        const px = tracePts[startIdx + j * 2]
+        const py = tracePts[startIdx + j * 2 + 1]
+        const dx = px - mouseX, dy = py - mouseY
+        const near = dx * dx + dy * dy < hrSq
+        if (near) {
+          if (!inSegment) { ctx.beginPath(); ctx.moveTo(px, py); inSegment = true }
+          else ctx.lineTo(px, py)
+        } else {
+          // One extra segment past the boundary for a smooth exit
+          if (inSegment) { ctx.lineTo(px, py); ctx.stroke(); inSegment = false }
+        }
+      }
+      if (inSegment) ctx.stroke()
+    }
+  }
+
   // Content readability vignette — applied once across the full canvas so the
   // seam boundary between tiles gets the same treatment as any other row.
   const isMobile = w < 768

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -15,6 +15,7 @@
  *   { type: 'resize', w, h, dpr, density }
  *   { type: 'theme',  theme, accent }
  *   { type: 'config', reset?, density?, traceAlpha?, padAlpha?, fadeStrength?, maxPulses?, fps? }
+ *   { type: 'pointer', x, y, pressed }
  */
 
 export {}
@@ -81,6 +82,11 @@ let h = 0
 let dpr = 1
 let reducedMotion = false
 let ready = false
+
+// Mouse state
+let mouseX = -1
+let mouseY = -1
+let mouseActive = false
 
 // Color cache
 let cachedR = 100
@@ -511,6 +517,87 @@ function resamplePulse(pl: PulseData) {
   pl.ti = ti
 }
 
+// ── Cursor interaction helpers ────────────────────────────────────────────
+
+function findNearestTrace(x: number, y: number): { traceIdx: number; distAlongPath: number; dist: number } | null {
+  let bestDist = Infinity
+  let bestTraceIdx = -1
+  let bestJ = 0
+  let bestPtCount = 0
+
+  for (let i = 0; i < traceCount; i++) {
+    const startIdx = traceMeta[i * 3]
+    const ptCount = traceMeta[i * 3 + 1]
+    for (let j = 0; j < ptCount; j++) {
+      const dx = tracePts[startIdx + j * 2] - x
+      const dy = tracePts[startIdx + j * 2 + 1] - y
+      const d2 = dx * dx + dy * dy
+      if (d2 < bestDist) {
+        bestDist = d2
+        bestTraceIdx = i
+        bestJ = j
+        bestPtCount = ptCount
+      }
+    }
+  }
+
+  const dist = Math.sqrt(bestDist)
+  if (dist > 300 || bestTraceIdx < 0) return null
+  const distAlongPath = bestPtCount > 1 ? bestJ / (bestPtCount - 1) : 0
+  return { traceIdx: bestTraceIdx, distAlongPath, dist }
+}
+
+function spawnClickPulse(x: number, y: number) {
+  const nearest = findNearestTrace(x, y)
+  if (!nearest || nearest.dist >= 200) return
+
+  const ti = nearest.traceIdx
+  const startIdx = traceMeta[ti * 3]
+  const ptCount = traceMeta[ti * 3 + 1]
+  if (ptCount < 2) return
+
+  const pts = new Float32Array(ptCount * 2)
+  for (let j = 0; j < ptCount * 2; j++) pts[j] = tracePts[startIdx + j]
+
+  const segLens = new Float32Array(ptCount - 1)
+  let totalLen = 0
+  for (let j = 0; j < ptCount - 1; j++) {
+    const ddx = pts[(j + 1) * 2] - pts[j * 2]
+    const ddy = pts[(j + 1) * 2 + 1] - pts[j * 2 + 1]
+    const slen = Math.sqrt(ddx * ddx + ddy * ddy)
+    segLens[j] = slen
+    totalLen += slen
+  }
+  if (totalLen < 10) return
+
+  const newPulse: PulseData = {
+    pts,
+    segLens,
+    totalLen,
+    pr: nearest.distAlongPath,
+    sp: 0.003,
+    ln: 0.08,
+    w: traceMeta[ti * 3 + 2],
+    ti,
+  }
+
+  if (pulseData.length >= maxPulses) {
+    // Replace the pulse closest to completion
+    let bestIdx = 0
+    let bestProgress = -1
+    for (let i = 0; i < pulseData.length; i++) {
+      const completionRatio = pulseData[i].pr / (1.0 + pulseData[i].ln)
+      if (completionRatio > bestProgress) {
+        bestProgress = completionRatio
+        bestIdx = i
+      }
+    }
+    pulseData[bestIdx] = newPulse
+  } else {
+    pulseData.push(newPulse)
+  }
+}
+
 // Advance pulse positions once per frame and return drawable states.
 // Separating update from draw allows drawScene to be called twice per frame
 // (once per tile) without double-advancing the animation.
@@ -640,6 +727,48 @@ function draw(time: number) {
   drawScene(time, drawablePulses)
   ctx.restore()
 
+  // ── Hover glow (viewport space, before vignette) ─────────────────────
+  if (mouseActive && mouseX >= 0) {
+    const hoverRadius = 120
+    const r = cachedR, g = cachedG, b = cachedB
+    const hg = ctx.createRadialGradient(mouseX, mouseY, 0, mouseX, mouseY, hoverRadius)
+    hg.addColorStop(0, `rgba(${r},${g},${b},${isLightMode ? 0.06 : 0.04})`)
+    hg.addColorStop(0.5, `rgba(${r},${g},${b},${isLightMode ? 0.03 : 0.02})`)
+    hg.addColorStop(1, `rgba(${r},${g},${b},0)`)
+    ctx.fillStyle = hg
+    ctx.beginPath()
+    ctx.arc(mouseX, mouseY, hoverRadius, 0, 6.2832)
+    ctx.fill()
+  }
+
+  // ── Trace proximity highlight (viewport space, before vignette) ──────
+  if (mouseActive && mouseX >= 0) {
+    const highlightRadius = 100
+    const highlightRadiusSq = highlightRadius * highlightRadius
+    const baseAlpha = isLightMode ? 0.15 : 0.10
+    ctx.strokeStyle = `rgba(${cachedR},${cachedG},${cachedB},${baseAlpha})`
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+    for (let i = 0; i < traceCount; i++) {
+      const startIdx = traceMeta[i * 3]
+      const ptCount = traceMeta[i * 3 + 1]
+      let near = false
+      for (let j = 0; j < ptCount; j++) {
+        const dx = tracePts[startIdx + j * 2] - mouseX
+        const dy = tracePts[startIdx + j * 2 + 1] - mouseY
+        if (dx * dx + dy * dy < highlightRadiusSq) { near = true; break }
+      }
+      if (!near) continue
+      ctx.lineWidth = traceMeta[i * 3 + 2] * traceWidthMult
+      ctx.beginPath()
+      ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
+      for (let j = 1; j < ptCount; j++) {
+        ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
+      }
+      ctx.stroke()
+    }
+  }
+
   // Content readability vignette — applied once across the full canvas so the
   // seam boundary between tiles gets the same treatment as any other row.
   const isMobile = w < 768
@@ -692,9 +821,18 @@ function stopLoop() {
     | { type: "resize"; w: number; h: number; dpr: number; density: number }
     | { type: "theme"; theme: Theme; accent: string }
     | { type: "config"; reset?: boolean; paused?: boolean; density?: number; traceAlpha?: number; padAlpha?: number; fadeStrength?: number; maxPulses?: number; fps?: number; glowIntensity?: number; pulseBrightness?: number; pulseSpeed?: number; traceWidth?: number }
+    | { type: "pointer"; x: number; y: number; pressed: boolean }
   >
 ) => {
   const msg = e.data
+
+  if (msg.type === "pointer") {
+    mouseX = msg.x
+    mouseY = msg.y
+    if (msg.pressed) spawnClickPulse(msg.x, msg.y)
+    mouseActive = true
+    return
+  }
 
   if (msg.type === "init") {
     offscreen = msg.canvas

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -64,6 +64,7 @@ let glowSp = new Float32Array(0)
 let glowCount = 0
 
 let pulseData: PulseData[] = []
+let clickPulses: PulseData[] = []
 
 // ── Admin config overrides (session-only, set via circuit-config CustomEvent) ──
 let currentDensity = 1.0
@@ -570,32 +571,24 @@ function spawnClickPulse(x: number, y: number) {
   }
   if (totalLen < 10) return
 
-  const newPulse: PulseData = {
+  // Randomize speed — some fast, some slow, some crawl
+  const speedTier = Math.random()
+  const sp = speedTier < 0.3
+    ? 0.001 + Math.random() * 0.002
+    : speedTier < 0.7
+    ? 0.003 + Math.random() * 0.004
+    : 0.008 + Math.random() * 0.006
+
+  clickPulses.push({
     pts,
     segLens,
     totalLen,
     pr: nearest.distAlongPath,
-    sp: 0.003,
+    sp,
     ln: 0.08,
     w: traceMeta[ti * 3 + 2],
     ti,
-  }
-
-  if (pulseData.length >= maxPulses) {
-    // Replace the pulse closest to completion
-    let bestIdx = 0
-    let bestProgress = -1
-    for (let i = 0; i < pulseData.length; i++) {
-      const completionRatio = pulseData[i].pr / (1.0 + pulseData[i].ln)
-      if (completionRatio > bestProgress) {
-        bestProgress = completionRatio
-        bestIdx = i
-      }
-    }
-    pulseData[bestIdx] = newPulse
-  } else {
-    pulseData.push(newPulse)
-  }
+  })
 }
 
 // Advance pulse positions once per frame and return drawable states.
@@ -604,6 +597,8 @@ function spawnClickPulse(x: number, y: number) {
 function computePulseStates(): DrawablePulse[] {
   if (reducedMotion) return []
   const result: DrawablePulse[] = []
+
+  // Regular pulses (capped by maxPulses, resample on completion)
   const limit = Math.min(maxPulses, pulseData.length)
   for (let _i = 0; _i < limit; _i++) {
     const pl = pulseData[_i]
@@ -614,20 +609,39 @@ function computePulseStates(): DrawablePulse[] {
         ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
         : 1.0
     pl.pr += pl.sp * pulseSpeedMult
-    // Pulse completed its journey — reset to start a new pass on a fresh trace.
-    // Must NOT reset inside `life <= 0` because pr=0 also gives life=0,
-    // which would trap the pulse in an infinite reset loop.
     if (pl.pr >= 1.0 + pl.ln) {
       pl.pr = 0
       resamplePulse(pl)
       continue
     }
-    if (life <= 0) continue  // still in the initial fade-in ramp (pr: 0 → ln)
+    if (life <= 0) continue
     const hd = Math.min(pl.pr, 1.0) * pl.totalLen
     const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
     if (hd - td < 1) continue
     result.push({ pl, life, hd, td })
   }
+
+  // Click-spawned pulses (no cap, removed on completion)
+  for (let i = clickPulses.length - 1; i >= 0; i--) {
+    const pl = clickPulses[i]
+    const life =
+      pl.pr < pl.ln
+        ? pl.pr / pl.ln
+        : pl.pr > 1.0
+        ? Math.max(0, 1 - (pl.pr - 1.0) / pl.ln)
+        : 1.0
+    pl.pr += pl.sp * pulseSpeedMult
+    if (pl.pr >= 1.0 + pl.ln) {
+      clickPulses.splice(i, 1)
+      continue
+    }
+    if (life <= 0) continue
+    const hd = Math.min(pl.pr, 1.0) * pl.totalLen
+    const td = Math.max(0, (pl.pr - pl.ln) * pl.totalLen)
+    if (hd - td < 1) continue
+    result.push({ pl, life, hd, td })
+  }
+
   return result
 }
 
@@ -726,48 +740,6 @@ function draw(time: number) {
   ctx.translate(0, h)
   drawScene(time, drawablePulses)
   ctx.restore()
-
-  // ── Hover glow (viewport space, before vignette) ─────────────────────
-  if (mouseActive && mouseX >= 0) {
-    const hoverRadius = 120
-    const r = cachedR, g = cachedG, b = cachedB
-    const hg = ctx.createRadialGradient(mouseX, mouseY, 0, mouseX, mouseY, hoverRadius)
-    hg.addColorStop(0, `rgba(${r},${g},${b},${isLightMode ? 0.06 : 0.04})`)
-    hg.addColorStop(0.5, `rgba(${r},${g},${b},${isLightMode ? 0.03 : 0.02})`)
-    hg.addColorStop(1, `rgba(${r},${g},${b},0)`)
-    ctx.fillStyle = hg
-    ctx.beginPath()
-    ctx.arc(mouseX, mouseY, hoverRadius, 0, 6.2832)
-    ctx.fill()
-  }
-
-  // ── Trace proximity highlight (viewport space, before vignette) ──────
-  if (mouseActive && mouseX >= 0) {
-    const highlightRadius = 100
-    const highlightRadiusSq = highlightRadius * highlightRadius
-    const baseAlpha = isLightMode ? 0.15 : 0.10
-    ctx.strokeStyle = `rgba(${cachedR},${cachedG},${cachedB},${baseAlpha})`
-    ctx.lineCap = "round"
-    ctx.lineJoin = "round"
-    for (let i = 0; i < traceCount; i++) {
-      const startIdx = traceMeta[i * 3]
-      const ptCount = traceMeta[i * 3 + 1]
-      let near = false
-      for (let j = 0; j < ptCount; j++) {
-        const dx = tracePts[startIdx + j * 2] - mouseX
-        const dy = tracePts[startIdx + j * 2 + 1] - mouseY
-        if (dx * dx + dy * dy < highlightRadiusSq) { near = true; break }
-      }
-      if (!near) continue
-      ctx.lineWidth = traceMeta[i * 3 + 2] * traceWidthMult
-      ctx.beginPath()
-      ctx.moveTo(tracePts[startIdx], tracePts[startIdx + 1])
-      for (let j = 1; j < ptCount; j++) {
-        ctx.lineTo(tracePts[startIdx + j * 2], tracePts[startIdx + j * 2 + 1])
-      }
-      ctx.stroke()
-    }
-  }
 
   // Content readability vignette — applied once across the full canvas so the
   // seam boundary between tiles gets the same treatment as any other row.


### PR DESCRIPTION
## Summary
- Click anywhere to spawn a light pulse on the nearest circuit trace
- Mouse hover creates a soft radial glow spotlight (120px radius) following the cursor
- Traces within 100px of cursor get a brightness boost (proximity highlight)

## Implementation
- Window-level mousemove (throttled ~30fps) + click listeners in `circuit-bg.tsx`
- Worker-side spatial lookup (`findNearestTrace`) over all trace points
- `spawnClickPulse` creates a new pulse starting at the clicked position along the nearest trace
- Hover effects render after both tiles but before the vignette, so they integrate naturally
- Only the OffscreenCanvas primary path modified (no fallback path changes)