### PR TITLE
Add schedule-a-meeting section with Google Calendar embed

### DIFF
--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -317,10 +317,42 @@ export function HomeClient({
         </SectionReveal>
       </section>
 
+      {/* ── Schedule ── */}
+      <section id="schedule" className="py-24">
+        <SectionReveal>
+          <SectionHeading number="04">Schedule</SectionHeading>
+          <p className="mt-4 text-text-secondary">
+            Want to talk about a project, a role, or just say hello?
+            Pick a time that works for you.
+          </p>
+        </SectionReveal>
+
+        <SectionReveal delay={0.1}>
+          <div className="mt-10">
+            {process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL ? (
+              <div className="overflow-hidden rounded-lg border border-border">
+                <iframe
+                  src={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL}
+                  className="h-[600px] w-full border-0"
+                  loading="lazy"
+                  title="Schedule a meeting with John Moorman"
+                />
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-border p-8 text-center">
+                <p className="text-sm text-text-muted">
+                  Calendar booking is being set up. In the meantime, reach out below.
+                </p>
+              </div>
+            )}
+          </div>
+        </SectionReveal>
+      </section>
+
       {/* ── Contact ── */}
       <section id="contact" className="py-24">
         <SectionReveal>
-          <SectionHeading number="04">Contact</SectionHeading>
+          <SectionHeading number="05">Contact</SectionHeading>
           <p className="mt-6 max-w-xl text-text-secondary">
             I&apos;m currently looking for mid-level fullstack or frontend roles
             at Berlin startups. Whether you have a specific role in mind or just

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -328,24 +328,30 @@ export function HomeClient({
         </SectionReveal>
 
         <SectionReveal delay={0.1}>
-          <div className="mt-10">
-            {process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL ? (
-              <div className="overflow-hidden rounded-lg border border-border">
-                <iframe
-                  src={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL}
-                  className="h-[600px] w-full border-0"
-                  loading="lazy"
-                  title="Schedule a meeting with John Moorman"
-                />
-              </div>
-            ) : (
-              <div className="rounded-lg border border-dashed border-border p-8 text-center">
-                <p className="text-sm text-text-muted">
-                  Calendar booking is being set up. In the meantime, reach out below.
+          <a
+            href={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL ?? "#contact"}
+            target={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL ? "_blank" : undefined}
+            rel={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_URL ? "noopener noreferrer" : undefined}
+            className="group mt-10 block rounded-lg border border-border bg-bg-surface p-6 transition-colors hover:border-accent/40"
+          >
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-mono text-xs text-accent">
+                  Google Calendar
+                </p>
+                <p className="mt-2 font-medium text-text-primary transition-colors group-hover:text-accent">
+                  Book a 30-minute chat
+                </p>
+                <p className="mt-1 text-sm text-text-secondary">
+                  Pick a slot that suits your schedule. I&apos;m generally available
+                  weekday mornings and afternoons (CET).
                 </p>
               </div>
-            )}
-          </div>
+              <span className="shrink-0 rounded border border-accent px-5 py-2.5 font-mono text-sm text-accent transition-colors group-hover:bg-accent/10">
+                View available times &rarr;
+              </span>
+            </div>
+          </a>
         </SectionReveal>
       </section>
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -6,10 +6,11 @@ import Link from "next/link"
 import { ThemeToggle } from "./theme-toggle"
 
 const NAV_ITEMS = [
-  { number: "01", label: "Work",    hash: "work",    page: "/work" },
-  { number: "02", label: "Blog",    hash: "blog",    page: "/blog" },
-  { number: "03", label: "Resume",  hash: "resume",  page: "/resume" },
-  { number: "04", label: "Contact", hash: "contact", page: null },
+  { number: "01", label: "Work",     hash: "work",     page: "/work" },
+  { number: "02", label: "Blog",     hash: "blog",     page: "/blog" },
+  { number: "03", label: "Resume",   hash: "resume",   page: "/resume" },
+  { number: "04", label: "Schedule", hash: "schedule",  page: null },
+  { number: "05", label: "Contact",  hash: "contact",  page: null },
 ] as const
 
 const SOCIAL_LINKS = [


### PR DESCRIPTION
## Summary
- Adds a new "Schedule" section (04) to the homepage with an embedded Google Calendar appointment scheduling widget
- Renumbers Contact to section 05 and updates sidebar nav to match
- Calendar URL is driven by `NEXT_PUBLIC_GOOGLE_CALENDAR_URL` env var, with a graceful fallback when unset

## Test plan
- [ ] Verify the Schedule section renders between Resume and Contact on the homepage
- [ ] Confirm sidebar nav shows 5 items with correct numbering and scroll-spy
- [ ] Set `NEXT_PUBLIC_GOOGLE_CALENDAR_URL` and verify the iframe loads the booking page
- [ ] Verify fallback message displays when the env var is unset