### PR TITLE
react-doctor pass: lift score from 69 to 80

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -43,7 +43,7 @@ export default function AboutPage() {
         &larr; Home
       </Link>
 
-      <h1 className="mt-8 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-8 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
         About
       </h1>
 

--- a/app/admin/(dashboard)/chats/[id]/page.tsx
+++ b/app/admin/(dashboard)/chats/[id]/page.tsx
@@ -26,7 +26,7 @@ export default async function ChatDetailPage({
           >
             &larr; Back
           </Link>
-          <h1 className="font-display text-2xl font-bold text-text-primary">
+          <h1 className="font-display text-2xl font-semibold text-text-primary">
             Chat Session
           </h1>
         </div>

--- a/app/admin/(dashboard)/chats/page.tsx
+++ b/app/admin/(dashboard)/chats/page.tsx
@@ -6,7 +6,7 @@ export default async function ChatsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-display text-2xl font-bold text-text-primary">
+      <h1 className="font-display text-2xl font-semibold text-text-primary">
         Chat Sessions{" "}
         <span className="font-mono text-base font-normal text-text-muted">
           ({chats.length})

--- a/app/admin/(dashboard)/circuit/page.tsx
+++ b/app/admin/(dashboard)/circuit/page.tsx
@@ -400,7 +400,7 @@ export default function CircuitConfigPage() {
             </button>
             <button
               onClick={() => setPanelCollapsed(c => !c)}
-              className="flex h-5 w-5 items-center justify-center rounded text-text-muted transition-colors hover:text-text-primary"
+              className="flex size-5 items-center justify-center rounded text-text-muted transition-colors hover:text-text-primary"
               title={panelCollapsed ? "Expand" : "Collapse"}
             >
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
@@ -489,7 +489,7 @@ export default function CircuitConfigPage() {
             onPointerMove={onResizeMove}
             onPointerUp={onResizeUp}
             style={{ touchAction: "none", cursor: "nwse-resize" }}
-            className="absolute bottom-0 right-0 flex h-5 w-5 items-end justify-end pb-1 pr-1"
+            className="absolute bottom-0 right-0 flex size-5 items-end justify-end pb-1 pr-1"
           >
             <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" className="text-text-muted opacity-50">
               <rect x="4" y="0" width="1.5" height="1.5" rx="0.5"/>

--- a/app/admin/(dashboard)/comments/page.tsx
+++ b/app/admin/(dashboard)/comments/page.tsx
@@ -6,7 +6,7 @@ export default async function CommentsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-display text-2xl font-bold text-text-primary">
+      <h1 className="font-display text-2xl font-semibold text-text-primary">
         Comments{" "}
         <span className="font-mono text-base font-normal text-text-muted">
           ({comments.length})

--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -16,7 +16,7 @@ export default async function AdminDashboardPage() {
 
   return (
     <div className="space-y-8">
-      <h1 className="font-display text-2xl font-bold text-text-primary">Dashboard</h1>
+      <h1 className="font-display text-2xl font-semibold text-text-primary">Dashboard</h1>
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/app/admin/(dashboard)/palette/page.tsx
+++ b/app/admin/(dashboard)/palette/page.tsx
@@ -265,7 +265,7 @@ export default function PalettePage() {
           Preview
         </p>
         <div className="space-y-4">
-          <h2 className="font-display text-2xl font-bold text-text-primary">
+          <h2 className="font-display text-2xl font-semibold text-text-primary">
             Hello, World.
           </h2>
           <p className="text-text-secondary">

--- a/app/admin/(dashboard)/palette/page.tsx
+++ b/app/admin/(dashboard)/palette/page.tsx
@@ -230,7 +230,7 @@ export default function PalettePage() {
           >
             <label htmlFor={`color-${key}`} className="relative cursor-pointer">
               <div
-                className="h-10 w-10 rounded-lg border border-border"
+                className="size-10 rounded-lg border border-border"
                 style={{ backgroundColor: currentTokens[key] || "#000" }}
               />
               <input

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -205,7 +205,7 @@ export default async function BlogPost({ params }: Props) {
             <span className="text-border">·</span>
             <span>{estimateReadTime(post.content)} min read</span>
           </div>
-          <h1 className="mt-2 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+          <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
             {post.frontmatter.title}
           </h1>
           {post.frontmatter.tags && post.frontmatter.tags.length > 0 && (

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -238,7 +238,7 @@ export default async function BlogPost({ params }: Props) {
         <div className="mt-6">
           <Suspense
             fallback={
-              <p className="text-sm text-text-muted">Loading comments...</p>
+              <p className="text-sm text-text-muted">Loading comments…</p>
             }
           >
             <CommentList postSlug={slug} />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -46,7 +46,7 @@ export default async function BlogIndex() {
       >
         &larr; Home
       </Link>
-      <h1 className="mt-8 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-8 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
         Blog
       </h1>
       <p className="mt-4 max-w-xl text-text-secondary">

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -9,7 +9,7 @@ export default function Error({
   return (
     <section className="flex min-h-[60vh] flex-col items-start justify-center">
       <p className="font-mono text-sm text-red-400">Error</p>
-      <h1 className="mt-2 font-display text-3xl font-bold">
+      <h1 className="mt-2 font-display text-3xl font-semibold">
         Something went wrong
       </h1>
       <p className="mt-4 text-text-secondary">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { Syne, DM_Sans, JetBrains_Mono } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import { MotionProvider } from "@/components/motion-provider"
 import { Sidebar } from "@/components/sidebar"
 import { ChatPanelLazy } from "@/components/chat-panel-lazy"
 
@@ -225,28 +226,30 @@ export default async function RootLayout({
       </head>
       <body className="antialiased">
         <ThemeProvider>
-          {isAdmin ? (
-            <>{children}</>
-          ) : (
-            <>
-              <Sidebar />
-              <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
-                <CircuitBgLazy navOffset />
-                <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
-                  {children}
+          <MotionProvider>
+            {isAdmin ? (
+              <>{children}</>
+            ) : (
+              <>
+                <Sidebar />
+                <div className="relative pt-14 md:ml-60 md:pt-0 print:ml-0 print:pt-0">
+                  <CircuitBgLazy navOffset />
+                  <div className="relative mx-auto max-w-[900px] px-6 md:px-12">
+                    {children}
+                  </div>
                 </div>
-              </div>
-              <ChatPanelLazy />
-              <PrefetchRoutes routes={allRoutes} />
-            </>
-          )}
-          <Analytics />
-          <Script
-            defer
-            src="https://umami-ek8u.vercel.app/script.js"
-            data-website-id="b5ed7964-94ba-48bd-b087-01adfd7a68dc"
-            strategy="afterInteractive"
-          />
+                <ChatPanelLazy />
+                <PrefetchRoutes routes={allRoutes} />
+              </>
+            )}
+            <Analytics />
+            <Script
+              defer
+              src="https://umami-ek8u.vercel.app/script.js"
+              data-website-id="b5ed7964-94ba-48bd-b087-01adfd7a68dc"
+              strategy="afterInteractive"
+            />
+          </MotionProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -4,7 +4,7 @@ export default function NotFound() {
   return (
     <section className="flex min-h-[60vh] flex-col items-start justify-center">
       <p className="font-mono text-sm text-accent">404</p>
-      <h1 className="mt-2 font-display text-3xl font-bold">Page not found</h1>
+      <h1 className="mt-2 font-display text-3xl font-semibold">Page not found</h1>
       <p className="mt-4 text-text-secondary">
         The page you&apos;re looking for doesn&apos;t exist or has been moved.
       </p>

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -10,9 +10,9 @@ export async function GET(request: Request) {
   const subtitle =
     url.searchParams.get("subtitle") ?? "Software Engineer · Berlin"
 
-  const photo = await fetch(`${origin}/images/og-about-img.jpeg`).then((r) =>
-    r.arrayBuffer()
-  )
+  const photo = await fetch(`${origin}/images/og-about-img.jpeg`, {
+    next: { revalidate: 3600 },
+  }).then((r) => r.arrayBuffer())
 
   const heading = title ?? "John Moorman"
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,15 +48,19 @@ export default async function Home() {
     href: `/blog/${p.slug}`,
   }))
 
-  const featuredWork = workPosts
-    .filter((p) => p.frontmatter.featured)
-    .map((p) => ({
-      title: p.frontmatter.title,
-      summary: p.frontmatter.description,
-      stats: p.frontmatter.stats ?? [],
-      tags: p.frontmatter.tags ?? [],
-      href: `/work/${p.slug}`,
-    }))
+  const featuredWork = workPosts.flatMap((p) =>
+    p.frontmatter.featured
+      ? [
+          {
+            title: p.frontmatter.title,
+            summary: p.frontmatter.description,
+            stats: p.frontmatter.stats ?? [],
+            tags: p.frontmatter.tags ?? [],
+            href: `/work/${p.slug}`,
+          },
+        ]
+      : []
+  )
 
   const challengeWork = workPosts
     .filter((p) => p.frontmatter.challenge === "10-in-10" && p.frontmatter.week != null)

--- a/app/promacro/delete/page.tsx
+++ b/app/promacro/delete/page.tsx
@@ -37,7 +37,7 @@ export default function PromacroDeletePage() {
         &larr; Home
       </Link>
 
-      <h1 className="mt-8 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-8 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
         Delete your Promacro account
       </h1>
 

--- a/app/promacro/delete/page.tsx
+++ b/app/promacro/delete/page.tsx
@@ -117,29 +117,35 @@ export default function PromacroDeletePage() {
         <ul className="mt-4 space-y-3 text-text-secondary leading-relaxed">
           <li>
             <span className="font-medium text-text-primary">
-              Account credentials
+              Account credentials:
             </span>{" "}
-            — your email address, hashed password, and any linked Apple sign-in
+            your email address, hashed password, and any linked Apple sign-in
             identifier.
           </li>
           <li>
-            <span className="font-medium text-text-primary">Profile data</span>{" "}
-            — sex, age, height, weight, activity level, display name.
-          </li>
-          <li>
-            <span className="font-medium text-text-primary">Meal history</span>{" "}
-            — every meal entry you have logged, including foods, quantities,
-            and computed macros.
-          </li>
-          <li>
-            <span className="font-medium text-text-primary">Preferences</span>{" "}
-            — tracked nutrients, ring assignments, units, theme.
+            <span className="font-medium text-text-primary">
+              Profile data:
+            </span>{" "}
+            sex, age, height, weight, activity level, display name.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Daily suggestions
+              Meal history:
             </span>{" "}
-            — any cached AI suggestions tied to your account.
+            every meal entry you have logged, including foods, quantities,
+            and computed macros.
+          </li>
+          <li>
+            <span className="font-medium text-text-primary">
+              Preferences:
+            </span>{" "}
+            tracked nutrients, ring assignments, units, theme.
+          </li>
+          <li>
+            <span className="font-medium text-text-primary">
+              Daily suggestions:
+            </span>{" "}
+            any cached AI suggestions tied to your account.
           </li>
         </ul>
       </div>
@@ -149,21 +155,21 @@ export default function PromacroDeletePage() {
         <ul className="mt-4 space-y-3 text-text-secondary leading-relaxed">
           <li>
             <span className="font-medium text-text-primary">
-              Anonymized crash reports
+              Anonymized crash reports:
             </span>{" "}
-            — Sentry stack traces collected before deletion are kept for up to
+            Sentry stack traces collected before deletion are kept for up to
             90 days for engineering diagnostics. They do not contain meals,
-            passwords, biometrics, or your email — only an internal account ID
+            passwords, biometrics, or your email, only an internal account ID
             that becomes orphaned once the account is deleted.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Infrastructure backups
+              Infrastructure backups:
             </span>{" "}
-            — Supabase and Vercel keep automated backups of their respective
+            Supabase and Vercel keep automated backups of their respective
             databases and request logs. These age out per their retention
-            policies (typically 7–30 days). After the backup window passes, no
-            copy of your data remains.
+            policies (typically 7 to 30 days). After the backup window passes,
+            no copy of your data remains.
           </li>
         </ul>
       </div>

--- a/app/promacro/privacy/page.tsx
+++ b/app/promacro/privacy/page.tsx
@@ -73,19 +73,19 @@ const subprocessors: {
     service: "Apple",
     href: "https://www.apple.com/legal/privacy/en-ww/",
     purpose: "Sign in with Apple (only if you choose this option)",
-    data: "Whatever Apple shares with us — typically email and optional display name",
+    data: "Whatever Apple shares with us (typically email and optional display name)",
   },
   {
     service: "USDA FoodData Central",
     href: "https://fdc.nal.usda.gov/",
     purpose: "Public food nutrition database",
-    data: "Food names only — no account or profile data",
+    data: "Food names only (no account or profile data)",
   },
   {
     service: "Open Food Facts",
     href: "https://world.openfoodfacts.org/terms-of-use",
     purpose: "Public food nutrition database",
-    data: "Food names only — no account or profile data",
+    data: "Food names only (no account or profile data)",
   },
 ]
 
@@ -133,58 +133,58 @@ export default function PromacroPrivacyPage() {
         <ul className="mt-4 space-y-3 text-text-secondary leading-relaxed">
           <li>
             <span className="font-medium text-text-primary">
-              Account data
+              Account data:
             </span>{" "}
-            — your email address and a hashed password, or your Apple ID (if you
+            your email address and a hashed password, or your Apple ID (if you
             sign in with Apple).
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Profile data
+              Profile data:
             </span>{" "}
-            — your sex, age, height, weight, and activity level. We use these to
+            your sex, age, height, weight, and activity level. We use these to
             compute your daily calorie, protein, and fiber targets using the
             Mifflin-St Jeor equation. We do not share this data, sell it, or use
             it for advertising.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Display name
+              Display name:
             </span>{" "}
-            — if you sign in with Apple and grant us your name, we store it on
+            if you sign in with Apple and grant us your name, we store it on
             your profile so the app can greet you. You can edit or clear it in
             Settings.
           </li>
           <li>
-            <span className="font-medium text-text-primary">Meal data</span> —
+            <span className="font-medium text-text-primary">Meal data:</span>{" "}
             the foods you log, including: food name, brand (if any), quantity,
             unit, computed macronutrients, and the date and time you logged the
             meal. Photos are not collected.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              AI parse text
+              AI parse text:
             </span>{" "}
-            — when you use the natural-language meal entry feature
+            when you use the natural-language meal entry feature
             (&quot;I had two eggs and toast&quot;), the text you type is sent to
             our AI parsing service (see Third Parties) so it can identify the
             foods you mentioned. The AI is instructed not to retain or train on
-            this text. We do not store the original text after parsing — only
+            this text. We do not store the original text after parsing, only
             the structured food list it produces.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Preferences
+              Preferences:
             </span>{" "}
-            — which nutrients you want to track, your ring assignments, your
+            which nutrients you want to track, your ring assignments, your
             unit system (metric or imperial), and your theme choice (light,
             dark, or system). Stored on your profile.
           </li>
           <li>
             <span className="font-medium text-text-primary">
-              Crash and error reports
+              Crash and error reports:
             </span>{" "}
-            — if the app crashes or hits an unexpected error, we collect a stack
+            if the app crashes or hits an unexpected error, we collect a stack
             trace and a small amount of context (which screen, which action) to
             help us fix bugs. These reports do not include the contents of your
             meals or your password. They may include your account ID.

--- a/app/promacro/privacy/page.tsx
+++ b/app/promacro/privacy/page.tsx
@@ -99,7 +99,7 @@ export default function PromacroPrivacyPage() {
         &larr; Home
       </Link>
 
-      <h1 className="mt-8 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-8 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
         Promacro Privacy Policy
       </h1>
 

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -61,7 +61,7 @@ const EXPERIENCE = [
     highlights: [
       <>Identified that the administrative function consumed 4 full salaries for entirely rule-based work; built an {b("automation suite")} to replace it</>,
       <>Automated the {b("complete student lifecycle")}: offer letters, payment tracking, PayPal reconciliation, confirmation/reminder/cancellation emails</>,
-      <>Enabled two part-time administrators to do the work of four — {b("~€74,000 in annual overhead savings")}</>,
+      <>Enabled two part-time administrators to do the work of four ({b("~€74,000 in annual overhead savings")})</>,
       <>{b("Payment reconciliation system")} with automated follow-ups: {b("18% increase")} in payment collection rate</>,
       <>Built the production website from scratch: {b("95/100 Lighthouse score")}, top-3 organic rankings, {b("8% organic traffic growth")}</>,
     ],

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -97,7 +97,7 @@ export default function ResumePage() {
 
       {/* Print button */}
       <div className="mt-4 flex items-center justify-between print:hidden">
-        <h1 className="font-display text-2xl font-bold">Resume</h1>
+        <h1 className="font-display text-2xl font-semibold">Resume</h1>
         <PrintButton />
       </div>
 
@@ -106,7 +106,7 @@ export default function ResumePage() {
 
         {/* Header */}
         <header>
-          <h2 className="font-display text-3xl font-bold tracking-tight print:text-2xl">
+          <h2 className="font-display text-3xl font-semibold tracking-tight print:text-2xl">
             John Moorman
           </h2>
           <p className="mt-1 text-lg text-text-secondary">Software Engineer</p>

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -197,7 +197,7 @@ export default async function WorkPost({ params }: Props) {
       </Link>
 
       <header className="mt-8">
-        <h1 className="font-display text-3xl font-bold tracking-tight sm:text-4xl">
+        <h1 className="font-display text-3xl font-semibold tracking-tight sm:text-4xl">
           {post.frontmatter.title}
         </h1>
         <p className="mt-4 text-lg text-text-secondary">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -153,7 +153,7 @@ export default async function WorkIndex() {
       >
         &larr; Home
       </Link>
-      <h1 className="mt-8 font-display text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-8 font-display text-3xl font-semibold tracking-tight sm:text-4xl">
         Work
       </h1>
       <p className="mt-4 max-w-xl text-text-secondary">

--- a/components/admin/admin-nav.tsx
+++ b/components/admin/admin-nav.tsx
@@ -47,14 +47,14 @@ export function AdminNav() {
         </div>
 
         <div className="flex items-center gap-4">
-          <a
+          <Link
             href="/"
             target="_blank"
             rel="noopener noreferrer"
             className="font-mono text-xs text-text-muted transition-colors hover:text-accent"
           >
             View site ↗
-          </a>
+          </Link>
           <form action={logoutAction}>
             <button
               type="submit"

--- a/components/admin/content-table.tsx
+++ b/components/admin/content-table.tsx
@@ -49,7 +49,7 @@ export function ContentTable({ posts }: { posts: ContentRow[] }) {
     }
   }
 
-  const sorted = [...posts].sort((a, b) => {
+  const sorted = posts.toSorted((a, b) => {
     let cmp = 0
     switch (sortKey) {
       case "title":

--- a/components/admin/delete-chat-button.tsx
+++ b/components/admin/delete-chat-button.tsx
@@ -9,7 +9,7 @@ export function DeleteChatButton({ chatId }: { chatId: string }) {
   const [confirming, setConfirming] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const router = useRouter()
+  const { push } = useRouter()
   const { show } = useToast()
 
   useEffect(() => {
@@ -31,13 +31,13 @@ export function DeleteChatButton({ chatId }: { chatId: string }) {
     const result = await deleteChatAction(chatId)
     if (result.success) {
       show("Chat session deleted.", "success")
-      router.push("/admin/chats")
+      push("/admin/chats")
     } else {
       show(result.error ?? "Failed to delete chat session.", "error")
       setDeleting(false)
       setConfirming(false)
     }
-  }, [confirming, chatId, show, router])
+  }, [confirming, chatId, show, push])
 
   return (
     <button

--- a/components/admin/frontmatter-form.tsx
+++ b/components/admin/frontmatter-form.tsx
@@ -69,8 +69,10 @@ export function FrontmatterForm({
           onChange={(e) => {
             const tags = e.target.value
               .split(",")
-              .map((t) => t.trim())
-              .filter(Boolean)
+              .flatMap((t) => {
+                const trimmed = t.trim()
+                return trimmed ? [trimmed] : []
+              })
             update("tags", tags)
           }}
           placeholder="Next.js, TypeScript, AI"

--- a/components/admin/frontmatter-form.tsx
+++ b/components/admin/frontmatter-form.tsx
@@ -84,7 +84,7 @@ export function FrontmatterForm({
           type="checkbox"
           checked={(frontmatter.draft as boolean) ?? false}
           onChange={(e) => update("draft", e.target.checked)}
-          className="h-4 w-4 rounded border-border bg-bg-surface accent-accent"
+          className="size-4 rounded border-border bg-bg-surface accent-accent"
         />
         <span className={labelClasses}>Draft</span>
       </label>
@@ -100,7 +100,7 @@ export function FrontmatterForm({
               type="checkbox"
               checked={(frontmatter.featured as boolean) ?? false}
               onChange={(e) => update("featured", e.target.checked)}
-              className="h-4 w-4 rounded border-border bg-bg-surface accent-accent"
+              className="size-4 rounded border-border bg-bg-surface accent-accent"
             />
             <span className={labelClasses}>Featured</span>
           </label>

--- a/components/admin/new-post-form.tsx
+++ b/components/admin/new-post-form.tsx
@@ -12,7 +12,7 @@ export function NewPostForm() {
   const [slug, setSlug] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState("")
-  const router = useRouter()
+  const { push } = useRouter()
   const { show } = useToast()
 
   const autoSlug = title
@@ -34,7 +34,7 @@ export function NewPostForm() {
       setOpen(false)
       setTitle("")
       setSlug("")
-      router.push(`/admin/content/${type}/${finalSlug}`)
+      push(`/admin/content/${type}/${finalSlug}`)
     } else {
       setError(result.error ?? "Failed to create post.")
     }

--- a/components/admin/toast.tsx
+++ b/components/admin/toast.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useCallback, useContext, useState } from "react"
+import { createContext, use, useCallback, useState } from "react"
 
 type ToastType = "success" | "error"
 
@@ -17,7 +17,7 @@ interface ToastContextValue {
 const ToastContext = createContext<ToastContextValue>({ show: () => {} })
 
 export function useToast() {
-  return useContext(ToastContext)
+  return use(ToastContext)
 }
 
 let nextId = 0

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -93,7 +93,7 @@ export function ChatPanel() {
     }
     const scrollHandler = () => dismiss()
     const timer = setTimeout(dismiss, 5000)
-    window.addEventListener("scroll", scrollHandler, { once: true })
+    window.addEventListener("scroll", scrollHandler, { once: true, passive: true })
     return () => {
       clearTimeout(timer)
       window.removeEventListener("scroll", scrollHandler)
@@ -107,11 +107,12 @@ export function ChatPanel() {
     try {
       localStorage.removeItem("chat_messages")
       localStorage.removeItem("chat_session_id")
+      sessionStorage.removeItem("chat_messages")
     } catch {
       // non-fatal
     }
     try {
-      const stored = sessionStorage.getItem("chat_messages")
+      const stored = sessionStorage.getItem("chat_messages:v1")
       if (stored) {
         const parsed = JSON.parse(stored) as Message[]
         if (Array.isArray(parsed) && parsed.length > 0) {
@@ -127,7 +128,7 @@ export function ChatPanel() {
   useEffect(() => {
     if (messages.length > 0) {
       try {
-        sessionStorage.setItem("chat_messages", JSON.stringify(messages))
+        sessionStorage.setItem("chat_messages:v1", JSON.stringify(messages))
       } catch {
         // Storage full or unavailable
       }

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback } from "react"
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion"
+import { m, AnimatePresence, useReducedMotion } from "framer-motion"
 import Image from "next/image"
 import ReactMarkdown from "react-markdown"
 import type { Components } from "react-markdown"
@@ -239,7 +239,7 @@ export function ChatPanel() {
       {/* Greeting speech bubble */}
       <AnimatePresence>
         {showGreeting && !open && (
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: 10, scale: 0.95 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.95 }}
@@ -253,12 +253,12 @@ export function ChatPanel() {
           >
             Hi! I&apos;m John&apos;s AI assistant. Ask me anything about his work.
             <span className="mt-1.5 block text-xs text-text-secondary">Click to chat &rarr;</span>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
 
       {/* Floating avatar trigger */}
-      <motion.button
+      <m.button
         onClick={() => setOpen(true)}
         className={`fixed bottom-6 right-6 z-40 flex items-center justify-center w-[52px] h-[52px] rounded-full border-2 border-accent/40 bg-bg-surface shadow-lg shadow-black/30 transition-colors hover:border-accent/60 print:hidden ${
           open ? "hidden" : ""
@@ -275,12 +275,12 @@ export function ChatPanel() {
           className="rounded-full"
         />
         <span className="absolute -top-0.5 -right-0.5 size-3.5 rounded-full border-2 border-bg bg-accent" />
-      </motion.button>
+      </m.button>
 
       {/* Backdrop */}
       <AnimatePresence>
         {open && (
-          <motion.div
+          <m.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -295,7 +295,7 @@ export function ChatPanel() {
       {/* Chat panel */}
       <AnimatePresence>
         {open && (
-          <motion.div
+          <m.div
             initial={
               shouldReduceMotion ? { opacity: 0 } : { x: "100%", opacity: 0 }
             }
@@ -462,7 +462,7 @@ export function ChatPanel() {
                 </button>
               </div>
             </form>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
     </>

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -273,7 +273,7 @@ export function ChatPanel() {
           height={36}
           className="rounded-full"
         />
-        <span className="absolute -top-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-bg bg-accent" />
+        <span className="absolute -top-0.5 -right-0.5 size-3.5 rounded-full border-2 border-bg bg-accent" />
       </motion.button>
 
       {/* Backdrop */}
@@ -432,7 +432,7 @@ export function ChatPanel() {
                 autoComplete="off"
                 value={honeypot}
                 onChange={(e) => setHoneypot(e.target.value)}
-                className="absolute h-0 w-0 opacity-0"
+                className="absolute size-0 opacity-0"
                 aria-hidden="true"
               />
 

--- a/components/circuit-bg.tsx
+++ b/components/circuit-bg.tsx
@@ -307,7 +307,8 @@ export function CircuitBg({ navOffset }: { navOffset?: boolean } = {}) {
           pl.pr += pl.sp
           if (pl.pr >= 1.0 + pl.ln) {
             // Pulse completed — pick a new unoccupied trace for the next pass
-            const occupied = new Set(pulseData.filter(p => p !== pl && p.pr > 0).map(p => p.ti))
+            const occupied = new Set<number>()
+            for (const p of pulseData) if (p !== pl && p.pr > 0) occupied.add(p.ti)
             let ti = 0, ptC = 0, att = 0
             do { ti = Math.floor(Math.random() * traceCount); ptC = traceMeta[ti * 3 + 1]; att++ }
             while ((ptC < 2 || occupied.has(ti)) && att < 20)

--- a/components/comment-form.tsx
+++ b/components/comment-form.tsx
@@ -21,7 +21,7 @@ export function CommentForm({
   turnstileSiteKey: string
 }) {
   const formRef = useRef<HTMLFormElement>(null)
-  const router = useRouter()
+  const { refresh } = useRouter()
   const [status, setStatus] = useState<Status>("idle")
   const [errorMessage, setErrorMessage] = useState("")
 
@@ -39,7 +39,7 @@ export function CommentForm({
       setStatus("success")
       formRef.current?.reset()
       window.turnstile?.reset()
-      router.refresh()
+      refresh()
       setTimeout(() => setStatus("idle"), 3000)
     } else {
       setStatus("error")

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -72,7 +72,7 @@ export function ContactForm() {
         autoComplete="off"
         value={honeypot}
         onChange={(e) => setHoneypot(e.target.value)}
-        className="absolute h-0 w-0 opacity-0"
+        className="absolute size-0 opacity-0"
         aria-hidden="true"
       />
 

--- a/components/cursor-glow.tsx
+++ b/components/cursor-glow.tsx
@@ -21,10 +21,15 @@ export function CursorGlow() {
     const isDark = () =>
       document.documentElement.getAttribute("data-theme") !== "light"
 
-    const attach = () =>
+    let attached = false
+    const attach = () => {
+      if (attached) return
+      attached = true
       window.addEventListener("mousemove", onMove, { passive: true })
-
+    }
     const detach = () => {
+      if (!attached) return
+      attached = false
       window.removeEventListener("mousemove", onMove)
       div.style.opacity = "0"
     }
@@ -32,7 +37,8 @@ export function CursorGlow() {
     if (isDark()) attach()
 
     const observer = new MutationObserver(() => {
-      isDark() ? attach() : detach()
+      if (isDark()) attach()
+      else detach()
     })
     observer.observe(document.documentElement, {
       attributes: true,
@@ -40,8 +46,9 @@ export function CursorGlow() {
     })
 
     return () => {
-      detach()
+      window.removeEventListener("mousemove", onMove)
       observer.disconnect()
+      div.style.opacity = "0"
     }
   }, [])
 

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { motion, useReducedMotion } from "framer-motion"
+import { m, useReducedMotion } from "framer-motion"
 import Link from "next/link"
 import { SectionReveal } from "@/components/section-reveal"
 import { ContactForm } from "@/components/contact-form"
@@ -77,28 +77,28 @@ export function HomeClient({
   return (
     <main>
       {/* ── Hero ── */}
-      <motion.section
+      <m.section
         className="flex min-h-screen flex-col justify-center py-24"
         variants={container}
         initial="hidden"
         animate="show"
       >
-        <motion.p variants={fadeUp} className="font-mono text-sm text-accent">
+        <m.p variants={fadeUp} className="font-mono text-sm text-accent">
           Hi, my name is
-        </motion.p>
-        <motion.h1
+        </m.p>
+        <m.h1
           variants={fadeUp}
           className="mt-5 font-display text-4xl font-bold leading-tight tracking-tight sm:text-5xl"
         >
           John Moorman.
-        </motion.h1>
-        <motion.h2
+        </m.h1>
+        <m.h2
           variants={fadeUp}
           className="font-display text-[clamp(1.5rem,4vw,3rem)] font-bold leading-tight text-text-secondary"
         >
           I write software that pays for itself.
-        </motion.h2>
-        <motion.div variants={fadeUp} className="mt-6 max-w-xl">
+        </m.h2>
+        <m.div variants={fadeUp} className="mt-6 max-w-xl">
           <p className="text-text-secondary">
             Software engineer in Berlin. I built an automation suite that saved a
             company €74K/year, letting two part-time administrators do the work of four. Now I ship AI-native
@@ -111,8 +111,8 @@ export function HomeClient({
           >
             Full story &rarr;
           </Link>
-        </motion.div>
-        <motion.div variants={fadeUp} className="mt-8 flex flex-wrap gap-4">
+        </m.div>
+        <m.div variants={fadeUp} className="mt-8 flex flex-wrap gap-4">
           <a
             href="mailto:john@johnmoorman.com"
             className="inline-flex items-center gap-2 rounded border border-accent px-6 py-3 font-mono text-sm text-accent transition-colors hover:bg-accent/10"
@@ -125,8 +125,8 @@ export function HomeClient({
           >
             See my work &darr;
           </a>
-        </motion.div>
-        <motion.div
+        </m.div>
+        <m.div
           variants={fadeUp}
           className="mt-6 flex flex-wrap items-center gap-5 text-text-muted"
         >
@@ -154,8 +154,8 @@ export function HomeClient({
           >
             GitHub
           </a>
-        </motion.div>
-      </motion.section>
+        </m.div>
+      </m.section>
 
       {/* ── Work ── */}
       <section id="work" className="py-24">
@@ -425,7 +425,7 @@ function ProjectCard({
   const shouldReduceMotion = useReducedMotion()
 
   return (
-    <motion.a
+    <m.a
       href={project.href}
       className="group relative block rounded-lg border border-border bg-bg-surface p-6 transition-colors hover:border-accent/40"
       whileHover={shouldReduceMotion ? {} : { y: -4 }}
@@ -460,7 +460,7 @@ function ProjectCard({
           <TagPill key={tag}>{tag}</TagPill>
         ))}
       </div>
-    </motion.a>
+    </m.a>
   )
 }
 
@@ -515,14 +515,14 @@ function CurrentProjectCard({
 
   if (project.href) {
     return (
-      <motion.a
+      <m.a
         href={project.href}
         className={`group block rounded-lg border p-4 transition-colors hover:border-accent/40 ${borderClass}`}
         whileHover={shouldReduceMotion ? {} : { y: -4 }}
         transition={{ type: "spring", stiffness: 300, damping: 30 }}
       >
         {inner}
-      </motion.a>
+      </m.a>
     )
   }
 

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -213,11 +213,15 @@ export function HomeClient({
 
         {/* Current building cards (shipped + in-progress only) */}
         <div className="mt-8 grid gap-4 sm:grid-cols-2">
-          {challengeWork.filter((p) => p.status !== "upcoming").map((project, i) => (
-            <SectionReveal key={project.week} delay={(i + 1) * 0.1}>
-              <CurrentProjectCard project={project} />
-            </SectionReveal>
-          ))}
+          {challengeWork.flatMap((project, i) =>
+            project.status === "upcoming"
+              ? []
+              : [
+                  <SectionReveal key={project.week} delay={(i + 1) * 0.1}>
+                    <CurrentProjectCard project={project} />
+                  </SectionReveal>,
+                ]
+          )}
         </div>
 
         {/* Featured projects */}

--- a/components/image-lightbox.tsx
+++ b/components/image-lightbox.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useCallback, useRef, useState } from "react"
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion"
+import { m, AnimatePresence, useReducedMotion } from "framer-motion"
 
 interface ImageLightboxProps {
   src: string
@@ -150,7 +150,7 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
   return (
     <AnimatePresence>
       {isOpen && (
-        <motion.div
+        <m.div
           className="fixed inset-0 z-[100] flex items-center justify-center p-4"
           initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -207,7 +207,7 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
           </div>
 
           {/* Entrance animation wrapper */}
-          <motion.div
+          <m.div
             initial={shouldReduceMotion ? {} : { scale: 0.9 }}
             animate={{ scale: 1 }}
             exit={shouldReduceMotion ? {} : { scale: 0.9 }}
@@ -231,8 +231,8 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
               onPointerUp={handlePointerUp}
               draggable={false}
             />
-          </motion.div>
-        </motion.div>
+          </m.div>
+        </m.div>
       )}
     </AnimatePresence>
   )

--- a/components/image-lightbox.tsx
+++ b/components/image-lightbox.tsx
@@ -177,7 +177,7 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
             )}
             <button
               onClick={zoomOut}
-              className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+              className="flex size-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
               aria-label="Zoom out"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -186,7 +186,7 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
             </button>
             <button
               onClick={zoomIn}
-              className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+              className="flex size-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
               aria-label="Zoom in"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -196,7 +196,7 @@ export function ImageLightbox({ src, alt, isOpen, onClose }: ImageLightboxProps)
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); onClose() }}
-              className="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+              className="flex size-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
               aria-label="Close image"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/components/lightbox-provider.tsx
+++ b/components/lightbox-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useState, useCallback } from "react"
+import { createContext, use, useState, useCallback } from "react"
 import { ImageLightbox } from "./image-lightbox"
 
 interface LightboxContextValue {
@@ -12,7 +12,7 @@ const LightboxContext = createContext<LightboxContextValue>({
 })
 
 export function useLightbox() {
-  return useContext(LightboxContext)
+  return use(LightboxContext)
 }
 
 export function LightboxProvider({ children }: { children: React.ReactNode }) {

--- a/components/mdx-audio.tsx
+++ b/components/mdx-audio.tsx
@@ -97,7 +97,7 @@ export function MdxAudio({
             type="button"
             onClick={toggle}
             aria-label={isPlaying ? "Pause" : "Play"}
-            className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-accent/40 text-accent transition-all hover:border-accent/70 hover:bg-accent/10"
+            className="flex size-9 flex-shrink-0 items-center justify-center rounded-full border border-accent/40 text-accent transition-all hover:border-accent/70 hover:bg-accent/10"
           >
             {isPlaying ? (
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -135,7 +135,7 @@ export function MdxAudio({
             </div>
             {/* Thumb */}
             <div
-              className="pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 rounded-full bg-accent/80 shadow-[0_0_6px_rgba(100,255,218,0.35)]"
+              className="pointer-events-none absolute size-2.5 -translate-x-1/2 rounded-full bg-accent/80 shadow-[0_0_6px_rgba(100,255,218,0.35)]"
               style={{ left: `${progress}%` }}
             />
           </div>

--- a/components/motion-provider.tsx
+++ b/components/motion-provider.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { LazyMotion, domAnimation } from "framer-motion"
+import type { ReactNode } from "react"
+
+export function MotionProvider({ children }: { children: ReactNode }) {
+  return <LazyMotion features={domAnimation}>{children}</LazyMotion>
+}

--- a/components/prefetch-routes.tsx
+++ b/components/prefetch-routes.tsx
@@ -36,6 +36,15 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
     })
 
     let cancelled = false
+    let pendingTimer: ReturnType<typeof setTimeout> | null = null
+
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => {
+        pendingTimer = setTimeout(() => {
+          pendingTimer = null
+          resolve()
+        }, ms)
+      })
 
     async function run() {
       // Wait for the page to fully settle before starting background fetches
@@ -43,7 +52,10 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
         if (typeof requestIdleCallback === "function") {
           requestIdleCallback(() => resolve(), { timeout: 3000 })
         } else {
-          setTimeout(resolve, 2000)
+          pendingTimer = setTimeout(() => {
+            pendingTimer = null
+            resolve()
+          }, 2000)
         }
       })
 
@@ -61,7 +73,7 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
         }
 
         // Small gap between fetches so we don't contend with user-initiated requests
-        await new Promise((r) => setTimeout(r, 100))
+        await wait(100)
       }
     }
 
@@ -69,6 +81,7 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
 
     return () => {
       cancelled = true
+      if (pendingTimer) clearTimeout(pendingTimer)
     }
   }, [routes, pathname, prefetch])
 

--- a/components/prefetch-routes.tsx
+++ b/components/prefetch-routes.tsx
@@ -12,7 +12,7 @@ import { useEffect, useRef } from "react"
  * Fetches sequentially with a small gap to avoid contention with user requests.
  */
 export function PrefetchRoutes({ routes }: { routes: string[] }) {
-  const router = useRouter()
+  const { prefetch } = useRouter()
   const pathname = usePathname()
   const started = useRef(false)
 
@@ -51,7 +51,7 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
         if (cancelled) break
 
         // Prefetch via Next.js router (caches RSC flight payload)
-        router.prefetch(route)
+        prefetch(route)
 
         // Also fetch the full HTML into the browser HTTP cache
         try {
@@ -70,7 +70,7 @@ export function PrefetchRoutes({ routes }: { routes: string[] }) {
     return () => {
       cancelled = true
     }
-  }, [routes, pathname, router])
+  }, [routes, pathname, prefetch])
 
   return null
 }

--- a/components/print-button.tsx
+++ b/components/print-button.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { motion } from "framer-motion"
+import { m } from "framer-motion"
 
 export function PrintButton() {
   return (
-    <motion.button
+    <m.button
       onClick={() => window.print()}
       className="group relative overflow-hidden rounded-lg border border-accent/40 bg-accent/15 px-5 py-2.5 font-mono text-sm font-medium text-accent transition-colors hover:border-accent/60 print:hidden"
       whileHover={{ scale: 1.02 }}
@@ -41,6 +41,6 @@ export function PrintButton() {
         </svg>
         Print / Save PDF
       </span>
-    </motion.button>
+    </m.button>
   )
 }

--- a/components/section-reveal.tsx
+++ b/components/section-reveal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { motion, useReducedMotion } from "framer-motion"
+import { m, useReducedMotion } from "framer-motion"
 import type { ReactNode } from "react"
 
 interface SectionRevealProps {
@@ -22,7 +22,7 @@ export function SectionReveal({
   const shouldReduceMotion = useReducedMotion()
 
   return (
-    <motion.div
+    <m.div
       initial={shouldReduceMotion ? false : { opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-80px" }}
@@ -30,6 +30,6 @@ export function SectionReveal({
       className={className}
     >
       {children}
-    </motion.div>
+    </m.div>
   )
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -83,7 +83,7 @@ export function Sidebar() {
   const [activeSection, setActiveSection] = useState("")
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const pathname = usePathname()
-  const router = useRouter()
+  const { push } = useRouter()
   const isHomePage = pathname === "/"
 
   // Scroll-spy: only relevant on homepage
@@ -127,12 +127,12 @@ export function Sidebar() {
       if (isHomePage && hash) {
         document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" })
       } else if (page) {
-        router.push(page)
+        push(page)
       } else if (hash) {
-        router.push(`/#${hash}`)
+        push(`/#${hash}`)
       }
     },
-    [isHomePage, router]
+    [isHomePage, push]
   )
 
   // Determine active item: scroll-spy on home, pathname match elsewhere

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -234,7 +234,7 @@ export function Sidebar() {
           <ThemeToggle />
           <button
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="relative z-50 flex h-8 w-8 flex-col items-center justify-center gap-1.5"
+            className="relative z-50 flex size-8 flex-col items-center justify-center gap-1.5"
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={mobileMenuOpen}
           >

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState, useCallback } from "react"
+import { createContext, use, useEffect, useRef, useState, useCallback } from "react"
 
 type Theme = "dark" | "light"
 
@@ -12,7 +12,7 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
 export function useTheme() {
-  const context = useContext(ThemeContext)
+  const context = use(ThemeContext)
   if (!context) {
     throw new Error("useTheme must be used within ThemeProvider")
   }
@@ -21,7 +21,7 @@ export function useTheme() {
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>("dark")
-  const [mounted, setMounted] = useState(false)
+  const mountedRef = useRef(false)
 
   useEffect(() => {
     const stored = localStorage.getItem("theme") as Theme | null
@@ -30,11 +30,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     } else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
       setTheme("light")
     }
-    setMounted(true)
+    mountedRef.current = true
   }, [])
 
   useEffect(() => {
-    if (!mounted) return
+    if (!mountedRef.current) return
     const root = document.documentElement
     if (theme === "light") {
       root.setAttribute("data-theme", "light")
@@ -42,7 +42,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       root.removeAttribute("data-theme")
     }
     localStorage.setItem("theme", theme)
-  }, [theme, mounted])
+  }, [theme])
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => (prev === "dark" ? "light" : "dark"))

--- a/components/work-demo.tsx
+++ b/components/work-demo.tsx
@@ -193,9 +193,9 @@ export function LiveEmbed({ src, title, height = 720, note }: LiveEmbedProps) {
       <div className="overflow-hidden rounded-xl border border-border bg-bg-surface">
         <div className="flex items-center justify-between border-b border-border bg-bg-elevated px-4 py-2">
           <div className="flex items-center gap-2">
-            <span className="h-2.5 w-2.5 rounded-full bg-text-muted/30" />
-            <span className="h-2.5 w-2.5 rounded-full bg-text-muted/30" />
-            <span className="h-2.5 w-2.5 rounded-full bg-text-muted/30" />
+            <span className="size-2.5 rounded-full bg-text-muted/30" />
+            <span className="size-2.5 rounded-full bg-text-muted/30" />
+            <span className="size-2.5 rounded-full bg-text-muted/30" />
             <span className="ml-3 font-mono text-xs text-text-muted">{title}</span>
           </div>
           <a

--- a/lib/admin/actions.ts
+++ b/lib/admin/actions.ts
@@ -170,6 +170,9 @@ export async function savePrompt(content: string): Promise<ActionResult> {
 
 // ── Palette ──
 
+const VAR_DECL_RE = /(--([\w-]+):\s*)([^;]+)(;)/g
+const LIGHT_BLOCK_RE = /\[data-theme="light"\]\s*\{([^}]+)\}/
+
 export interface PaletteColors {
   dark: Record<string, string>
   light: Record<string, string>
@@ -184,25 +187,22 @@ export async function savePalette(colors: PaletteColors): Promise<ActionResult> 
   try {
     let css = await fs.readFile(cssPath, "utf-8")
 
-    // Replace :root block values
-    for (const [key, value] of Object.entries(colors.dark)) {
-      const varName = `--${key}`
-      const regex = new RegExp(`(${varName}:\\s*)([^;]+)(;)`)
-      css = css.replace(regex, `$1${value}$3`)
-    }
+    // Single pass over each block: match any `--var: value;` declaration and
+    // replace from the new map. Avoids recompiling a regex per token.
+    const replaceVars = (block: string, vars: Record<string, string>) =>
+      block.replace(VAR_DECL_RE, (match, prefix: string, name: string, _val: string, suffix: string) => {
+        const next = vars[name]
+        return next ? `${prefix}${next}${suffix}` : match
+      })
 
-    // Replace [data-theme="light"] block values
-    for (const [key, value] of Object.entries(colors.light)) {
-      const varName = `--${key}`
-      // Match inside [data-theme="light"] block specifically
-      const lightBlock = css.match(/\[data-theme="light"\]\s*\{([^}]+)\}/)
-      if (lightBlock) {
-        const updatedBlock = lightBlock[1].replace(
-          new RegExp(`(${varName}:\\s*)([^;]+)(;)`),
-          `$1${value}$3`
-        )
-        css = css.replace(lightBlock[1], updatedBlock)
-      }
+    // :root block — outside any [data-theme] block. Replace dark vars there.
+    css = replaceVars(css, colors.dark)
+
+    // [data-theme="light"] block.
+    const lightBlock = css.match(LIGHT_BLOCK_RE)
+    if (lightBlock) {
+      const updatedBlock = replaceVars(lightBlock[1], colors.light)
+      css = css.replace(lightBlock[1], updatedBlock)
     }
 
     await fs.writeFile(cssPath, css, "utf-8")

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -35,24 +35,27 @@ export async function getPosts(type: "blog" | "work", includeDrafts = false): Pr
   }
 
   const posts = await Promise.all(
-    files
-      .filter((f) => f.endsWith(".mdx") && !f.startsWith("_"))
-      .map(async (filename) => {
-        const filePath = path.join(dir, filename)
-        const raw = await fs.readFile(filePath, "utf-8")
-        const { data, content } = matter(raw)
+    files.flatMap((filename) => {
+      if (!filename.endsWith(".mdx") || filename.startsWith("_")) return []
+      return [
+        (async () => {
+          const filePath = path.join(dir, filename)
+          const raw = await fs.readFile(filePath, "utf-8")
+          const { data, content } = matter(raw)
 
-        // Filter out drafts in production
-        if (data.draft && process.env.NODE_ENV === "production" && !includeDrafts) {
-          return null
-        }
+          // Filter out drafts in production
+          if (data.draft && process.env.NODE_ENV === "production" && !includeDrafts) {
+            return null
+          }
 
-        return {
-          slug: filename.replace(/\.mdx$/, ""),
-          frontmatter: data as PostFrontmatter,
-          content,
-        }
-      })
+          return {
+            slug: filename.replace(/\.mdx$/, ""),
+            frontmatter: data as PostFrontmatter,
+            content,
+          }
+        })(),
+      ]
+    })
   )
 
   return posts

--- a/lib/site-context.ts
+++ b/lib/site-context.ts
@@ -73,7 +73,7 @@ async function computeEntries(): Promise<IndexEntry[]> {
 
   const entries: IndexEntry[] = [
     ...blog.map((post) => toEntry(post, "blog", workBySlug.get(post.slug)?.frontmatter)),
-    ...work.filter((p) => !blogSlugs.has(p.slug)).map((post) => toEntry(post, "work")),
+    ...work.flatMap((p) => (blogSlugs.has(p.slug) ? [] : [toEntry(p, "work")])),
   ]
 
   entries.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())

--- a/workers/circuit-worker.ts
+++ b/workers/circuit-worker.ts
@@ -516,7 +516,8 @@ function ptAt(pl: PulseData, d: number): [number, number] {
 // Re-assign a pulse to a new random unoccupied trace so each cycle looks different.
 function resamplePulse(pl: PulseData) {
   if (traceCount === 0) return
-  const occupied = new Set(pulseData.filter(p => p !== pl && p.pr > 0).map(p => p.ti))
+  const occupied = new Set<number>()
+  for (const p of pulseData) if (p !== pl && p.pr > 0) occupied.add(p.ti)
   let ti = 0, ptC = 0, attempts = 0
   do {
     ti = Math.floor(Math.random() * traceCount)


### PR DESCRIPTION
## Summary

Ran `npx react-doctor@latest` and worked through the report. Score went from **69/100 (165 issues)** to **80/100 (83 issues)** across 23 atomic commits. Each commit is one logical change.

### Real fixes
- **LazyMotion adoption** across `section-reveal`, `print-button`, `chat-panel`, `image-lightbox`, `home-client` (~30kb bundle savings; new `MotionProvider` wraps the app inside `ThemeProvider`).
- **React 19 `use()`** in `theme-provider`, `lightbox-provider`, `admin/toast` (replaces `useContext`).
- **`mounted` state → `useRef`** in `theme-provider` (one fewer render per theme change).
- **Cursor-glow effect cleanup** made explicit and `attach()` idempotent (no listener leaks across theme flips).
- **Prefetch-routes timer cleanup** tracks the pending `setTimeout` and clears it on unmount.
- **Single-pass iterations** via `flatMap` in `lib/content.ts`, `lib/site-context.ts`, `app/page.tsx`, `components/home-client.tsx`, plus `for…of` rewrites in `circuit-bg` / `circuit-worker`.
- **`router.{push,prefetch,refresh}` destructured** at call sites (sidebar, comment-form, new-post-form, prefetch-routes, delete-chat-button) — clearer dep arrays for the React Compiler.
- **Hoisted palette regex** in `lib/admin/actions.ts`; CSS vars now replaced in a single pass per block.

### Quick wins
- `w-N h-N` → `size-N` (17 sites).
- `[...arr].sort()` → `arr.toSorted()` in admin content table.
- `flatMap` for tag splitting in `frontmatter-form`.
- Versioned `chat_messages:v1` sessionStorage key.
- Passive `scroll` listener on the chat greeting dismissal.
- `next/link` for the admin "View site" link.
- Hourly `revalidate` on the OG photo `fetch`.
- Typographic ellipsis in the comments fallback.

### Design system compliance
- **Em dashes removed from JSX text** (Promacro privacy/delete pages, resume bullet) — replaced with parens or colon-prefix style. Matches user's stated preference.
- **`font-bold` → `font-semibold` on non-hero h1s** (15 files). The site's design system in `CLAUDE.md` explicitly says "Syne 700–800 hero, **600 section heads**." The two hero h1s on the homepage stay `font-bold` (intentional per design system).

### Skipped (false positives or design choices)
- `server-auth-actions` on `loginAction` (it IS the auth), `logoutAction`, and anonymous `addComment` (Turnstile-protected).
- `rendering-hydration-mismatch-time` ×16 — all are `new Date(staticString)` from frontmatter, not `new Date()`.
- `dangerouslySetInnerHTML` ×7 — JSON-LD schema scripts and the inline pre-React theme script.
- `nextjs-no-img-element` in `mdx-og-link` and lightbox — arbitrary external URLs and CSS-transformed image.
- `nextjs-no-native-script` on the theme script — must be inline to avoid theme flicker.
- `client-passive-event-listeners` on the lightbox wheel handler — explicitly calls `preventDefault`.
- `array-index-as-key` on static fixed-length lists, append-only chat threads, and skeleton loaders.
- `useReducer` and `giant-component` refactors — judged over-engineering for this codebase.
- `useEffectEvent` (React 19 experimental).

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Browsed in dev: home (hero animations + circuit bg), blog index + post, work index, about, resume, promacro privacy, admin login. All renders match prior intent.
- [x] Verified chat panel still slides in with spring animation (LazyMotion regression check).
- [x] Verified em-dash replacements read naturally.
- [ ] Verify Vercel preview matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)